### PR TITLE
[FEAT] TimeSlot 도메인-JPA 엔티티 분리 및 Mapper 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'com.github.Miche-Let:common:dev-SNAPSHOT'
+	implementation 'org.mapstruct:mapstruct:1.6.3'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,11 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'com.github.Miche-Let:common:dev-SNAPSHOT'
 	implementation 'org.mapstruct:mapstruct:1.6.3'
-
+	
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ java {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 ext {
@@ -27,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'com.github.Miche-Let:common:dev-SNAPSHOT'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/michelet/timeslotservice/TimeslotserviceApplication.java
+++ b/src/main/java/com/michelet/timeslotservice/TimeslotserviceApplication.java
@@ -3,6 +3,10 @@ package com.michelet.timeslotservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+
+/**
+ * 타임슬롯 서비스 애플리케이션의 실행을 담당하는 메인 클래스.
+ */
 @SpringBootApplication
 public class TimeslotserviceApplication {
 

--- a/src/main/java/com/michelet/timeslotservice/config/AuditorConfig.java
+++ b/src/main/java/com/michelet/timeslotservice/config/AuditorConfig.java
@@ -14,6 +14,10 @@ import java.util.UUID;
 @Configuration
 public class AuditorConfig {
 
+    /**
+     * 현재 작업자의 UUID를 제공하는 AuditorAware 빈을 생성합니다.
+     * @return UUID를 담은 Optional 객체
+     */
     @Bean
     public AuditorAware<UUID> auditorAware() {
         // MVP 및 로컬 테스트 통과를 위한 임시 UUID 제공

--- a/src/main/java/com/michelet/timeslotservice/config/AuditorConfig.java
+++ b/src/main/java/com/michelet/timeslotservice/config/AuditorConfig.java
@@ -1,0 +1,19 @@
+package com.michelet.timeslotservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Configuration
+public class AuditorConfig {
+
+    @Bean
+    public AuditorAware<UUID> auditorAware() {
+        // MVP 및 로컬 테스트 통과를 위한 임시 UUID 제공
+        // TODO: 추후 게이트웨이/Security Context 연동 시 수정
+        return () -> Optional.of(UUID.fromString("00000000-0000-0000-0000-000000000000"));
+    }
+}

--- a/src/main/java/com/michelet/timeslotservice/config/AuditorConfig.java
+++ b/src/main/java/com/michelet/timeslotservice/config/AuditorConfig.java
@@ -7,6 +7,10 @@ import org.springframework.data.domain.AuditorAware;
 import java.util.Optional;
 import java.util.UUID;
 
+
+/**
+ * JPA Auditing 기능을 활성화하여 생성자 및 수정자 UUID를 자동 주입하기 위한 설정 클래스.
+ */
 @Configuration
 public class AuditorConfig {
 

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -71,7 +71,6 @@ public class TimeSlot {
      * @param requiredCapacity 차감할 인원 수
      * @throws BusinessException 잔여 인원이 부족하거나 마감된 경우 발생
      */
-    
     public void deduct(int requiredCapacity) {
         if (requiredCapacity <= 0) {
         throw new BusinessException(TimeSlotErrorCode.INVALID_CAPACITY_REQUEST);

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -11,6 +11,10 @@ import java.util.UUID;
 import com.michelet.common.exception.BusinessException;
 import com.michelet.timeslotservice.exception.TimeSlotErrorCode;
 
+/**
+ * 타임슬롯 도메인 객체.
+ * 식당의 예약 가능한 특정 시간대와 수용 인원 상태를 관리합니다.
+ */
 @Getter
 public class TimeSlot {
     private final UUID id;
@@ -36,6 +40,14 @@ public class TimeSlot {
                     int remainingCapacity, TimeSlotStatus status, long version,
                     LocalDateTime createdAt, UUID createdBy, LocalDateTime updatedAt, 
                     UUID updatedBy, LocalDateTime deletedAt, UUID deletedBy) {
+        
+
+        if (capacity < 0 || remainingCapacity < 0) {
+            throw new BusinessException(TimeSlotErrorCode.INVALID_CAPACITY);
+        }
+        if (startTime != null && endTime != null && !startTime.isBefore(endTime)) {
+            throw new BusinessException(TimeSlotErrorCode.INVALID_TIME_RANGE);
+        }
         this.id = id;
         this.restaurantId = restaurantId;
         this.targetDate = targetDate;
@@ -54,7 +66,16 @@ public class TimeSlot {
         this.deletedBy = deletedBy;
     }
 
+    /**
+     * 타임슬롯의 예약 가능 인원을 차감합니다.
+     * @param requiredCapacity 차감할 인원 수
+     * @throws BusinessException 잔여 인원이 부족하거나 마감된 경우 발생
+     */
+    
     public void deduct(int requiredCapacity) {
+        if (requiredCapacity <= 0) {
+        throw new BusinessException(TimeSlotErrorCode.INVALID_CAPACITY_REQUEST);
+        }
         if (this.status == TimeSlotStatus.CLOSED) {
             throw new BusinessException(TimeSlotErrorCode.TIME_SLOT_CLOSED);
         }

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -8,6 +8,9 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 
+import com.michelet.common.exception.BusinessException;
+import com.michelet.timeslotservice.exception.TimeSlotErrorCode;
+
 @Getter
 public class TimeSlot {
     private final UUID id;
@@ -53,10 +56,10 @@ public class TimeSlot {
 
     public void deduct(int requiredCapacity) {
         if (this.status == TimeSlotStatus.CLOSED) {
-            throw new IllegalStateException("Time slot is already closed.");
+            throw new BusinessException(TimeSlotErrorCode.TIME_SLOT_CLOSED);
         }
         if (this.remainingCapacity < requiredCapacity) {
-            throw new IllegalArgumentException("Not enough remaining capacity.");
+            throw new BusinessException(TimeSlotErrorCode.NOT_ENOUGH_CAPACITY);
         }
 
         this.remainingCapacity -= requiredCapacity;

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -1,0 +1,68 @@
+package com.michelet.timeslotservice.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Getter
+public class TimeSlot {
+    private final UUID id;
+    private final UUID restaurantId;
+    private final LocalDate targetDate;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+    private final int capacity;
+    private int remainingCapacity;
+    private TimeSlotStatus status;
+    private final long version;
+
+    private final LocalDateTime createdAt;
+    private final UUID createdBy;
+    private final LocalDateTime updatedAt;
+    private final UUID updatedBy;
+    private final LocalDateTime deletedAt;
+    private final UUID deletedBy;
+
+    @Builder
+    public TimeSlot(UUID id, UUID restaurantId, LocalDate targetDate, 
+                    LocalTime startTime, LocalTime endTime, int capacity, 
+                    int remainingCapacity, TimeSlotStatus status, long version,
+                    LocalDateTime createdAt, UUID createdBy, LocalDateTime updatedAt, 
+                    UUID updatedBy, LocalDateTime deletedAt, UUID deletedBy) {
+        this.id = id;
+        this.restaurantId = restaurantId;
+        this.targetDate = targetDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.capacity = capacity;
+        this.remainingCapacity = remainingCapacity;
+        this.status = status != null ? status : TimeSlotStatus.OPENED;
+        this.version = version;
+        
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
+        this.deletedAt = deletedAt;
+        this.deletedBy = deletedBy;
+    }
+
+    public void deduct(int requiredCapacity) {
+        if (this.status == TimeSlotStatus.CLOSED) {
+            throw new IllegalStateException("Time slot is already closed.");
+        }
+        if (this.remainingCapacity < requiredCapacity) {
+            throw new IllegalArgumentException("Not enough remaining capacity.");
+        }
+
+        this.remainingCapacity -= requiredCapacity;
+
+        if (this.remainingCapacity == 0) {
+            this.status = TimeSlotStatus.CLOSED;
+        }
+    }
+}

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -42,12 +42,14 @@ public class TimeSlot {
                     UUID updatedBy, LocalDateTime deletedAt, UUID deletedBy) {
         
 
-        if (capacity < 0 || remainingCapacity < 0) {
-            throw new BusinessException(TimeSlotErrorCode.INVALID_CAPACITY);
-        }
         if (startTime != null && endTime != null && !startTime.isBefore(endTime)) {
             throw new BusinessException(TimeSlotErrorCode.INVALID_TIME_RANGE);
         }
+
+        if (capacity <= 0 || remainingCapacity < 0 || remainingCapacity > capacity) {
+            throw new BusinessException(TimeSlotErrorCode.INVALID_CAPACITY);
+        }
+
         this.id = id;
         this.restaurantId = restaurantId;
         this.targetDate = targetDate;

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -33,7 +33,24 @@ public class TimeSlot {
     private final UUID updatedBy;
     private final LocalDateTime deletedAt;
     private final UUID deletedBy;
-
+    /**
+     * 생성자.
+     * @param id 타임슬롯 ID
+     * @param restaurantId 식당 ID
+     * @param targetDate 타겟 날짜
+     * @param startTime 시작 시간
+     * @param endTime 종료 시간
+     * @param capacity 수용 인원
+     * @param remainingCapacity 잔여 수용 인원
+     * @param status 상태
+     * @param version 버전
+     * @param createdAt 생성 시간
+     * @param createdBy 생성자
+     * @param updatedAt 수정 시간
+     * @param updatedBy 수정자
+     * @param deletedAt 삭제 시간
+     * @param deletedBy 삭제자
+     */
     @Builder
     public TimeSlot(UUID id, UUID restaurantId, LocalDate targetDate, 
                     LocalTime startTime, LocalTime endTime, int capacity, 
@@ -41,11 +58,10 @@ public class TimeSlot {
                     LocalDateTime createdAt, UUID createdBy, LocalDateTime updatedAt, 
                     UUID updatedBy, LocalDateTime deletedAt, UUID deletedBy) {
         
-
-        if (startTime != null && endTime != null && !startTime.isBefore(endTime)) {
+        
+        if (restaurantId == null || targetDate == null || startTime == null || endTime == null) {
             throw new BusinessException(TimeSlotErrorCode.INVALID_TIME_RANGE);
         }
-
         if (capacity <= 0 || remainingCapacity < 0 || remainingCapacity > capacity) {
             throw new BusinessException(TimeSlotErrorCode.INVALID_CAPACITY);
         }
@@ -57,7 +73,9 @@ public class TimeSlot {
         this.endTime = endTime;
         this.capacity = capacity;
         this.remainingCapacity = remainingCapacity;
-        this.status = status != null ? status : TimeSlotStatus.OPENED;
+        this.status = (status != null)
+                ? status
+                : (remainingCapacity == 0 ? TimeSlotStatus.CLOSED : TimeSlotStatus.OPENED);
         this.version = version;
         
         this.createdAt = createdAt;

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlotStatus.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlotStatus.java
@@ -1,5 +1,8 @@
 package com.michelet.timeslotservice.domain;
 
+/**
+ * 타임슬롯의 현재 개방 및 마감 상태를 정의하는 Enum 클래스.
+ */
 public enum TimeSlotStatus {
     OPENED,
     CLOSED

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlotStatus.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlotStatus.java
@@ -1,0 +1,6 @@
+package com.michelet.timeslotservice.domain;
+
+public enum TimeSlotStatus {
+    OPENED,
+    CLOSED
+}

--- a/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
+++ b/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
@@ -11,11 +11,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TimeSlotErrorCode implements ErrorCode {
     
+    /** 타임슬롯 조회 실패 에러 */
     TIME_SLOT_NOT_FOUND("TS_001", 404, "해당 타임슬롯을 찾을 수 없습니다."),
+
+    /** 타임슬롯 마감 에러 */
     TIME_SLOT_CLOSED("TS_002", 400, "이미 마감된 타임슬롯입니다."),
+
+    /** 수용 인원 부족 에러 */
     NOT_ENOUGH_CAPACITY("TS_003", 400, "타임슬롯의 잔여 수용 인원이 부족합니다."),
+
+    /** 유효하지 않은 수용 인원 요청 에러 */
     INVALID_CAPACITY_REQUEST("TS_004", 400, "유효하지 않은 수용 인원 요청입니다. 요청된 인원 수는 1 이상이어야 합니다."),
+
+    /** 수용 인원 음수 에러 */
     INVALID_CAPACITY("TS_005", 400, "수용 인원은 음수일 수 없습니다."),
+
+    /** 유효하지 않은 시간 범위 에러 */
     INVALID_TIME_RANGE("TS_006", 400, "시작 시간은 종료 시간보다 이전이어야 합니다.");
 
     private final String code;

--- a/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
+++ b/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
@@ -4,6 +4,9 @@ import com.michelet.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 타임슬롯 도메인에서 발생하는 비즈니스 예외 코드 모음.
+ */
 @Getter
 @RequiredArgsConstructor
 public enum TimeSlotErrorCode implements ErrorCode {

--- a/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
+++ b/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
@@ -1,0 +1,18 @@
+package com.michelet.timeslotservice.exception;
+
+import com.michelet.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TimeSlotErrorCode implements ErrorCode {
+    
+    TIME_SLOT_NOT_FOUND("TS_001", 404, "해당 타임슬롯을 찾을 수 없습니다."),
+    TIME_SLOT_CLOSED("TS_002", 400, "이미 마감된 타임슬롯입니다."),
+    NOT_ENOUGH_CAPACITY("TS_003", 400, "타임슬롯의 잔여 수용 인원이 부족합니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
+++ b/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
@@ -23,11 +23,11 @@ public enum TimeSlotErrorCode implements ErrorCode {
     /** 유효하지 않은 수용 인원 요청 에러 */
     INVALID_CAPACITY_REQUEST("TS_004", 400, "유효하지 않은 수용 인원 요청입니다. 요청된 인원 수는 1 이상이어야 합니다."),
 
-    /** 수용 인원 음수 에러 */
-    INVALID_CAPACITY("TS_005", 400, "수용 인원은 음수일 수 없습니다."),
-
-    /** 유효하지 않은 시간 범위 에러 */
-    INVALID_TIME_RANGE("TS_006", 400, "시작 시간은 종료 시간보다 이전이어야 합니다.");
+    /** 수용 인원 설정 오류 */
+    INVALID_CAPACITY("TS_005", 400, "타임슬롯의 수용 인원 설정이 올바르지 않습니다."),
+    
+    /** 시간 범위 설정 오류 */
+    INVALID_TIME_RANGE("TS_006", 400, "시작 시간은 종료 시간보다 앞서야 합니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
+++ b/src/main/java/com/michelet/timeslotservice/exception/TimeSlotErrorCode.java
@@ -10,7 +10,10 @@ public enum TimeSlotErrorCode implements ErrorCode {
     
     TIME_SLOT_NOT_FOUND("TS_001", 404, "해당 타임슬롯을 찾을 수 없습니다."),
     TIME_SLOT_CLOSED("TS_002", 400, "이미 마감된 타임슬롯입니다."),
-    NOT_ENOUGH_CAPACITY("TS_003", 400, "타임슬롯의 잔여 수용 인원이 부족합니다.");
+    NOT_ENOUGH_CAPACITY("TS_003", 400, "타임슬롯의 잔여 수용 인원이 부족합니다."),
+    INVALID_CAPACITY_REQUEST("TS_004", 400, "유효하지 않은 수용 인원 요청입니다. 요청된 인원 수는 1 이상이어야 합니다."),
+    INVALID_CAPACITY("TS_005", 400, "수용 인원은 음수일 수 없습니다."),
+    INVALID_TIME_RANGE("TS_006", 400, "시작 시간은 종료 시간보다 이전이어야 합니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/michelet/timeslotservice/repository/TimeSlotRepository.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/TimeSlotRepository.java
@@ -1,0 +1,11 @@
+package com.michelet.timeslotservice.repository;
+
+import com.michelet.timeslotservice.repository.entity.TimeSlotEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TimeSlotRepository extends JpaRepository<TimeSlotEntity, UUID> {
+ 
+    
+}

--- a/src/main/java/com/michelet/timeslotservice/repository/TimeSlotRepository.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/TimeSlotRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
+
+/**
+ * 타임슬롯 데이터의 영속성(DB 저장/조회)을 관리하는 Spring Data JPA 리포지토리.
+ */
 public interface TimeSlotRepository extends JpaRepository<TimeSlotEntity, UUID> {
  
-    
+
 }

--- a/src/main/java/com/michelet/timeslotservice/repository/entity/TimeSlotEntity.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/entity/TimeSlotEntity.java
@@ -74,7 +74,7 @@ public class TimeSlotEntity extends BaseEntity {
         this.endTime = endTime;
         this.capacity = capacity;
         this.remainingCapacity = remainingCapacity;
-        this.status = status;
+        this.status = (status != null) ? status : TimeSlotStatus.OPENED;
         this.version = version;
     }
 }

--- a/src/main/java/com/michelet/timeslotservice/repository/entity/TimeSlotEntity.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/entity/TimeSlotEntity.java
@@ -51,6 +51,18 @@ public class TimeSlotEntity extends BaseEntity {
     @Column(name = "version", nullable = false)
     private Long version;
 
+    /**
+     * 생성자.
+     * @param id 타임슬롯 ID
+     * @param restaurantId 식당 ID
+     * @param targetDate 타겟 날짜
+     * @param startTime 시작 시간
+     * @param endTime 종료 시간
+     * @param capacity 수용 인원
+     * @param remainingCapacity 잔여 수용 인원
+     * @param status 상태
+     * @param version 버전
+     */
     @Builder
     public TimeSlotEntity(UUID id, UUID restaurantId, LocalDate targetDate,
                           LocalTime startTime, LocalTime endTime, int capacity,

--- a/src/main/java/com/michelet/timeslotservice/repository/entity/TimeSlotEntity.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/entity/TimeSlotEntity.java
@@ -12,6 +12,9 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
 
+/**
+ * DB의 p_time_slot 테이블과 매핑되는 JPA 엔티티 클래스.
+ */
 @Entity
 @Table(name = "p_time_slot")
 @Getter

--- a/src/main/java/com/michelet/timeslotservice/repository/entity/TimeSlotEntity.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/entity/TimeSlotEntity.java
@@ -1,0 +1,65 @@
+package com.michelet.timeslotservice.repository.entity;
+
+import com.michelet.common.entity.BaseEntity;
+import com.michelet.timeslotservice.domain.TimeSlotStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_time_slot")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TimeSlotEntity extends BaseEntity {
+
+    @Id
+    @Column(name = "time_slot_id")
+    private UUID id;
+
+    @Column(name = "restaurant_id", nullable = false)
+    private UUID restaurantId;
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "capacity", nullable = false)
+    private int capacity;
+
+    @Column(name = "remaining_capacity", nullable = false)
+    private int remainingCapacity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private TimeSlotStatus status;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
+
+    @Builder
+    public TimeSlotEntity(UUID id, UUID restaurantId, LocalDate targetDate,
+                          LocalTime startTime, LocalTime endTime, int capacity,
+                          int remainingCapacity, TimeSlotStatus status, Long version) {
+        this.id = id;
+        this.restaurantId = restaurantId;
+        this.targetDate = targetDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.capacity = capacity;
+        this.remainingCapacity = remainingCapacity;
+        this.status = status;
+        this.version = version;
+    }
+}

--- a/src/main/java/com/michelet/timeslotservice/repository/mapper/TimeSlotMapper.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/mapper/TimeSlotMapper.java
@@ -5,6 +5,9 @@ import com.michelet.timeslotservice.repository.entity.TimeSlotEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
+/**
+ * 순수 도메인 객체(TimeSlot)와 JPA 엔티티(TimeSlotEntity) 간의 데이터 변환을 담당하는 매퍼 인터페이스.
+ */
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface TimeSlotMapper {
 

--- a/src/main/java/com/michelet/timeslotservice/repository/mapper/TimeSlotMapper.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/mapper/TimeSlotMapper.java
@@ -1,0 +1,14 @@
+package com.michelet.timeslotservice.repository.mapper;
+
+import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.repository.entity.TimeSlotEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface TimeSlotMapper {
+
+    TimeSlotEntity toEntity(TimeSlot domain);
+
+    TimeSlot toDomain(TimeSlotEntity entity);
+}

--- a/src/main/java/com/michelet/timeslotservice/repository/mapper/TimeSlotMapper.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/mapper/TimeSlotMapper.java
@@ -11,7 +11,17 @@ import org.mapstruct.ReportingPolicy;
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface TimeSlotMapper {
 
+    /**
+     * 순수 도메인 객체를 JPA 엔티티로 변환합니다.
+     * @param domain 타임슬롯 도메인 객체
+     * @return 변환된 엔티티
+     */
     TimeSlotEntity toEntity(TimeSlot domain);
 
+    /**
+     * JPA 엔티티를 순수 도메인 객체로 변환합니다.
+     * @param entity 타임슬롯 JPA 엔티티
+     * @return 변환된 도메인 객체
+     */
     TimeSlot toDomain(TimeSlotEntity entity);
 }

--- a/src/test/java/com/michelet/timeslotservice/repository/TimeSlotRepositoryTest.java
+++ b/src/test/java/com/michelet/timeslotservice/repository/TimeSlotRepositoryTest.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.Commit;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -26,7 +25,6 @@ class TimeSlotRepositoryTest {
     private TimeSlotRepository timeSlotRepository;
 
     @Test
-    @Commit
     @DisplayName("TimeSlotEntity can be saved and found by ID")
     void saveAndFindById_Success() {
         UUID id = UUID.randomUUID();

--- a/src/test/java/com/michelet/timeslotservice/repository/TimeSlotRepositoryTest.java
+++ b/src/test/java/com/michelet/timeslotservice/repository/TimeSlotRepositoryTest.java
@@ -6,7 +6,6 @@ import com.michelet.timeslotservice.repository.entity.TimeSlotEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -17,7 +16,6 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(AuditorConfig.class)
 class TimeSlotRepositoryTest {
 

--- a/src/test/java/com/michelet/timeslotservice/repository/TimeSlotRepositoryTest.java
+++ b/src/test/java/com/michelet/timeslotservice/repository/TimeSlotRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.michelet.timeslotservice.repository;
+
+import com.michelet.timeslotservice.config.AuditorConfig;
+import com.michelet.timeslotservice.domain.TimeSlotStatus;
+import com.michelet.timeslotservice.repository.entity.TimeSlotEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.Commit;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(AuditorConfig.class)
+class TimeSlotRepositoryTest {
+
+    @Autowired
+    private TimeSlotRepository timeSlotRepository;
+
+    @Test
+    @Commit
+    @DisplayName("TimeSlotEntity can be saved and found by ID")
+    void saveAndFindById_Success() {
+        UUID id = UUID.randomUUID();
+        TimeSlotEntity entity = TimeSlotEntity.builder()
+                .id(id)
+                .restaurantId(UUID.randomUUID())
+                .targetDate(LocalDate.of(2026, 5, 2))
+                .startTime(LocalTime.of(12, 0))
+                .endTime(LocalTime.of(13, 0))
+                .capacity(4)
+                .remainingCapacity(4)
+                .status(TimeSlotStatus.OPENED)
+                .build();
+
+        // When
+        TimeSlotEntity saved = timeSlotRepository.save(entity);
+        TimeSlotEntity found = timeSlotRepository.findById(saved.getId()).get();
+
+        // Then
+        assertThat(found.getId()).isEqualTo(id);
+        assertThat(found.getCreatedAt()).isNotNull();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 타임슬롯 서비스의 핵심 도메인인 '예약 가능한 시간대(Time Slot)' 데이터를 관리하기 위한 JPA Entity 모델링 및 Spring Data JPA Repository 인터페이스 초기 구현. JPA 테스트 코드 작성.

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #3   \


## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1401" height="404" alt="image" src="https://github.com/user-attachments/assets/fd2efc62-b16e-4b0a-a33f-b7cd3bcb4faf" />
<br><br>
<img width="1416" height="206" alt="image" src="https://github.com/user-attachments/assets/781b0764-d10e-44ed-9f98-07591ca009c7" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 식당 예약 시간대 관리 기능 추가
  * 시간대별 잔여 예약 용량 추적 및 자동 상태(열림/닫힘) 전환
  * 예약 요청 시 잔여 용량 검증 및 차감 로직 적용

* **Chores**
  * 빌드 설정 및 의존성 업데이트
  * 감사(auditing) 설정 추가

* **Tests**
  * 저장소 관련 JPA 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->