### PR TITLE
[FEAT] TimeSlot 비즈니스 로직(Service) 구현

### DIFF
--- a/src/main/java/com/michelet/timeslotservice/repository/TimeSlotRepository.java
+++ b/src/main/java/com/michelet/timeslotservice/repository/TimeSlotRepository.java
@@ -3,6 +3,8 @@ package com.michelet.timeslotservice.repository;
 import com.michelet.timeslotservice.repository.entity.TimeSlotEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 
@@ -11,5 +13,9 @@ import java.util.UUID;
  */
 public interface TimeSlotRepository extends JpaRepository<TimeSlotEntity, UUID> {
  
+    /**
+     * 특정 식당의 특정 날짜에 해당하는 모든 타임슬롯을 조회합니다.
+     */
+    List<TimeSlotEntity> findAllByRestaurantIdAndTargetDate(UUID restaurantId, LocalDate targetDate);
 
 }

--- a/src/main/java/com/michelet/timeslotservice/service/TimeSlotService.java
+++ b/src/main/java/com/michelet/timeslotservice/service/TimeSlotService.java
@@ -1,0 +1,62 @@
+package com.michelet.timeslotservice.service;
+
+import com.michelet.common.exception.BusinessException;
+import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.exception.TimeSlotErrorCode;
+import com.michelet.timeslotservice.repository.TimeSlotRepository;
+import com.michelet.timeslotservice.repository.entity.TimeSlotEntity;
+import com.michelet.timeslotservice.repository.mapper.TimeSlotMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 타임슬롯과 관련된 핵심 비즈니스 로직을 처리하는 서비스 클래스.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TimeSlotService {
+
+    private final TimeSlotRepository timeSlotRepository;
+    private final TimeSlotMapper timeSlotMapper;
+
+    /**
+     * 특정 식당의 지정된 날짜에 열려있는 타임슬롯 목록을 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public List<TimeSlot> getAvailableTimeSlots(UUID restaurantId, LocalDate targetDate) {
+        return timeSlotRepository.findAllByRestaurantIdAndTargetDate(restaurantId, targetDate)
+                .stream()
+                .map(timeSlotMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 타임슬롯의 예약 가능 인원을 차감합니다.
+     * 트랜잭션 종료 시 낙관적 락(@Version)을 통해 동시성 문제를 방어합니다.
+     */
+    @Transactional
+    public void deductCapacity(UUID timeSlotId, int requiredCapacity) {
+
+        TimeSlotEntity entity = timeSlotRepository.findById(timeSlotId)
+                .orElseThrow(() -> new BusinessException(TimeSlotErrorCode.TIME_SLOT_NOT_FOUND));
+
+        TimeSlot domain = timeSlotMapper.toDomain(entity);
+
+        domain.deduct(requiredCapacity);
+
+        TimeSlotEntity updatedEntity = timeSlotMapper.toEntity(domain);
+
+        timeSlotRepository.save(updatedEntity);
+        
+        log.info("타임슬롯 차감 성공: ID={}, 요청인원={}, 남은인원={}", 
+                timeSlotId, requiredCapacity, domain.getRemainingCapacity());
+    }
+}

--- a/src/test/java/com/michelet/timeslotservice/service/TimeSlotServiceTest.java
+++ b/src/test/java/com/michelet/timeslotservice/service/TimeSlotServiceTest.java
@@ -1,0 +1,200 @@
+package com.michelet.timeslotservice.service;
+
+import com.michelet.common.exception.BusinessException;
+import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.domain.TimeSlotStatus;
+import com.michelet.timeslotservice.exception.TimeSlotErrorCode;
+import com.michelet.timeslotservice.repository.TimeSlotRepository;
+import com.michelet.timeslotservice.repository.entity.TimeSlotEntity;
+import com.michelet.timeslotservice.repository.mapper.TimeSlotMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TimeSlotServiceTest {
+
+    @InjectMocks
+    private TimeSlotService timeSlotService;
+
+    @Mock
+    private TimeSlotRepository timeSlotRepository;
+
+    @Mock
+    private TimeSlotMapper timeSlotMapper;
+
+    @Test
+    @DisplayName("특정 식당과 날짜의 예약 가능한 타임슬롯 목록을 정상적으로 조회한다.")
+    void getAvailableTimeSlots_Success() {
+        // Given
+        UUID timeSlotId = UUID.randomUUID();
+        UUID restaurantId = UUID.randomUUID();
+        LocalDate targetDate = LocalDate.of(2026, 5, 2);
+        LocalTime startTime = LocalTime.of(12, 0);
+        LocalTime endTime = LocalTime.of(13, 0);
+        
+        // 🌟 모든 필수 파라미터 완벽 주입
+        TimeSlotEntity entity = TimeSlotEntity.builder()
+                .id(timeSlotId)
+                .restaurantId(restaurantId)
+                .targetDate(targetDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .capacity(4)
+                .remainingCapacity(4)
+                .status(TimeSlotStatus.OPENED)
+                .version(0L)
+                .build();
+                
+        TimeSlot domain = TimeSlot.builder()
+                .id(timeSlotId)
+                .restaurantId(restaurantId)
+                .targetDate(targetDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .capacity(4)
+                .remainingCapacity(4)
+                .status(TimeSlotStatus.OPENED)
+                .version(0L)
+                .build();
+
+        given(timeSlotRepository.findAllByRestaurantIdAndTargetDate(restaurantId, targetDate))
+                .willReturn(List.of(entity));
+        given(timeSlotMapper.toDomain(entity)).willReturn(domain);
+
+        // When
+        List<TimeSlot> result = timeSlotService.getAvailableTimeSlots(restaurantId, targetDate);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRestaurantId()).isEqualTo(restaurantId);
+    }
+
+    @Test
+    @DisplayName("타임슬롯의 수용 인원을 정상적으로 차감한다.")
+    void deductCapacity_Success() {
+        // Given
+        UUID timeSlotId = UUID.randomUUID();
+        UUID restaurantId = UUID.randomUUID();
+        LocalDate targetDate = LocalDate.of(2026, 5, 2);
+        LocalTime startTime = LocalTime.of(12, 0);
+        LocalTime endTime = LocalTime.of(13, 0);
+        
+        TimeSlotEntity entity = TimeSlotEntity.builder()
+                .id(timeSlotId)
+                .restaurantId(restaurantId)
+                .targetDate(targetDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .capacity(4)
+                .remainingCapacity(4)
+                .status(TimeSlotStatus.OPENED)
+                .version(0L)
+                .build();
+                
+        TimeSlot domain = TimeSlot.builder()
+                .id(timeSlotId)
+                .restaurantId(restaurantId)
+                .targetDate(targetDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .capacity(4)
+                .remainingCapacity(4)
+                .status(TimeSlotStatus.OPENED)
+                .version(0L)
+                .build();
+                
+        TimeSlotEntity updatedEntity = TimeSlotEntity.builder()
+                .id(timeSlotId)
+                .restaurantId(restaurantId)
+                .targetDate(targetDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .capacity(4)
+                .remainingCapacity(2) // 4명에서 2명으로 차감됨
+                .status(TimeSlotStatus.OPENED)
+                .version(0L)
+                .build();
+
+        given(timeSlotRepository.findById(timeSlotId)).willReturn(Optional.of(entity));
+        given(timeSlotMapper.toDomain(entity)).willReturn(domain);
+        given(timeSlotMapper.toEntity(domain)).willReturn(updatedEntity);
+
+        // When
+        timeSlotService.deductCapacity(timeSlotId, 2);
+
+        // Then
+        assertThat(domain.getRemainingCapacity()).isEqualTo(2);
+        verify(timeSlotRepository).save(updatedEntity); 
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 타임슬롯을 차감하려고 하면 예외가 발생한다.")
+    void deductCapacity_Fail_NotFound() {
+        // Given
+        UUID timeSlotId = UUID.randomUUID();
+        given(timeSlotRepository.findById(timeSlotId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> timeSlotService.deductCapacity(timeSlotId, 2))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(TimeSlotErrorCode.TIME_SLOT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("잔여 인원보다 많은 인원을 차감하려고 하면 예외가 발생한다.")
+    void deductCapacity_Fail_NotEnoughCapacity() {
+        // Given
+        UUID timeSlotId = UUID.randomUUID();
+        UUID restaurantId = UUID.randomUUID();
+        LocalDate targetDate = LocalDate.of(2026, 5, 2);
+        LocalTime startTime = LocalTime.of(12, 0);
+        LocalTime endTime = LocalTime.of(13, 0);
+        
+        TimeSlotEntity entity = TimeSlotEntity.builder()
+                .id(timeSlotId)
+                .restaurantId(restaurantId)
+                .targetDate(targetDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .capacity(4)
+                .remainingCapacity(1) // 1명만 남은 상태
+                .status(TimeSlotStatus.OPENED)
+                .version(0L)
+                .build();
+                
+        TimeSlot domain = TimeSlot.builder()
+                .id(timeSlotId)
+                .restaurantId(restaurantId)
+                .targetDate(targetDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .capacity(4)
+                .remainingCapacity(1) 
+                .status(TimeSlotStatus.OPENED)
+                .version(0L)
+                .build();
+
+        given(timeSlotRepository.findById(timeSlotId)).willReturn(Optional.of(entity));
+        given(timeSlotMapper.toDomain(entity)).willReturn(domain);
+
+        // When & Then (1명 남았는데 2명 차감 요청)
+        assertThatThrownBy(() -> timeSlotService.deductCapacity(timeSlotId, 2))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(TimeSlotErrorCode.NOT_ENOUGH_CAPACITY.getMessage());
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 타임슬롯 데이터의 조율과 핵심 비즈니스 규칙(예약 차감, 타임슬롯 생성)을 통제하기 위한 TimeSlotService 계층 구현. 도메인 모델과 JPA 엔티티 간의 매핑을 수행하며 트랜잭션을 관리

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #5   \


## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1425" height="386" alt="image" src="https://github.com/user-attachments/assets/edf38658-b6c5-4945-abc8-7654d38571bf" />

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 날짜의 사용 가능한 시간대 조회 기능 추가
  * 시간대 예약 시 용량 차감 기능 추가
  * 용량 부족 및 데이터 미존재 상황에 대한 오류 처리 추가

* **테스트**
  * 새로운 기능의 성공 시나리오 및 오류 경로에 대한 포괄적인 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->