### PR TITLE
[FEAT] Presentation 계층(Controller 및 DTO) API 구현

### DIFF
--- a/src/main/java/com/michelet/timeslotservice/presentation/code/TimeSlotSuccessCode.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/code/TimeSlotSuccessCode.java
@@ -1,0 +1,23 @@
+package com.michelet.timeslotservice.presentation.code;
+
+import com.michelet.common.response.SuccessCode;
+
+/**
+ * 타임슬롯 관련 API 성공 응답 코드 모음.
+ */
+public enum TimeSlotSuccessCode implements SuccessCode {
+    
+    INQUIRY_SUCCESS("TS_OK_001", "타임슬롯 조회가 완료되었습니다."),
+    DEDUCT_SUCCESS("TS_OK_002", "타임슬롯 예약 차감이 완료되었습니다.");
+
+    private final String code;
+    private final String message;
+
+    TimeSlotSuccessCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override public String getCode() { return code; }
+    @Override public String getMessage() { return message; }
+}

--- a/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotController.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotController.java
@@ -5,6 +5,8 @@ import com.michelet.timeslotservice.application.service.TimeSlotService;
 import com.michelet.timeslotservice.presentation.code.TimeSlotSuccessCode;
 import com.michelet.timeslotservice.presentation.dto.request.TimeSlotDeductCapacityRequest;
 import com.michelet.timeslotservice.presentation.dto.response.TimeSlotResponse;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
@@ -47,7 +49,7 @@ public class TimeSlotController {
     @PostMapping("/{timeSlotId}/deduct")
     public ApiResponse<Void> deductCapacity(
             @PathVariable UUID timeSlotId,
-            @RequestBody TimeSlotDeductCapacityRequest request) {
+            @Valid @RequestBody TimeSlotDeductCapacityRequest request) {
 
         timeSlotService.deductCapacity(timeSlotId, request.requiredCapacity());
         

--- a/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotController.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotController.java
@@ -1,0 +1,56 @@
+package com.michelet.timeslotservice.presentation.controller;
+
+import com.michelet.common.response.ApiResponse;
+import com.michelet.timeslotservice.application.service.TimeSlotService;
+import com.michelet.timeslotservice.presentation.code.TimeSlotSuccessCode;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotDeductCapacityRequest;
+import com.michelet.timeslotservice.presentation.dto.response.TimeSlotResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/timeslots")
+@RequiredArgsConstructor
+public class TimeSlotController {
+
+    private final TimeSlotService timeSlotService;
+    /**
+     * 특정 식당의 특정 날짜에 해당하는 타임슬롯 목록을 조회하는 API 엔드포인트.
+     * 클라이언트 화면에서 마감된 슬롯을 비활성화 처리할 수 있도록 CLOSED 상태도 포함하여 반환합니다.
+     */
+    @GetMapping
+    public ApiResponse<List<TimeSlotResponse>> getTimeSlots(
+            @RequestParam UUID restaurantId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate) {
+
+        List<TimeSlotResponse> responses = timeSlotService.getTimeSlotsByDate(restaurantId, targetDate)
+                .stream()
+                .map(TimeSlotResponse::from)
+                .collect(Collectors.toList());
+
+        return ApiResponse.ok(TimeSlotSuccessCode.INQUIRY_SUCCESS, responses);
+    }
+
+    /**
+     * 특정 타임슬롯의 예약 가능 인원을 차감하는 API 엔드포인트.
+     * 트랜잭션 종료 시 낙관적 락(@Version)을 통해 동시성 문제를 방어합니다.
+     * @param timeSlotId
+     * @param request
+     * @return
+     */
+    @PostMapping("/{timeSlotId}/deduct")
+    public ApiResponse<Void> deductCapacity(
+            @PathVariable UUID timeSlotId,
+            @RequestBody TimeSlotDeductCapacityRequest request) {
+
+        timeSlotService.deductCapacity(timeSlotId, request.requiredCapacity());
+        
+        return ApiResponse.ok(TimeSlotSuccessCode.DEDUCT_SUCCESS, null);
+    }
+}

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotDeductCapacityRequest.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotDeductCapacityRequest.java
@@ -1,0 +1,9 @@
+package com.michelet.timeslotservice.presentation.dto.request;
+
+/**
+ * 타임슬롯 인원 차감 요청 DTO
+ */
+public record TimeSlotDeductCapacityRequest(
+        int requiredCapacity
+) {
+}

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotDeductCapacityRequest.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotDeductCapacityRequest.java
@@ -1,9 +1,14 @@
 package com.michelet.timeslotservice.presentation.dto.request;
 
+import jakarta.validation.constraints.Min;
+
 /**
  * 타임슬롯 인원 차감 요청 DTO
  */
 public record TimeSlotDeductCapacityRequest(
+
+        @Min(value = 1, message = "차감 인원은 최소 1명 이상이어야 합니다.")
         int requiredCapacity
+        
 ) {
 }

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/response/TimeSlotResponse.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/response/TimeSlotResponse.java
@@ -1,0 +1,35 @@
+package com.michelet.timeslotservice.presentation.dto.response;
+
+import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.domain.TimeSlotStatus;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+/**
+ * 타임슬롯 기본 응답 DTO
+ */
+public record TimeSlotResponse(
+        UUID id,
+        UUID restaurantId,
+        LocalDate targetDate,
+        LocalTime startTime,
+        LocalTime endTime,
+        int capacity,
+        int remainingCapacity,
+        TimeSlotStatus status
+) {
+    public static TimeSlotResponse from(TimeSlot domain) {
+        return new TimeSlotResponse(
+                domain.getId(),
+                domain.getRestaurantId(),
+                domain.getTargetDate(),
+                domain.getStartTime(),
+                domain.getEndTime(),
+                domain.getCapacity(),
+                domain.getRemainingCapacity(),
+                domain.getStatus()
+        );
+    }
+}

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotControllerTest.java
@@ -1,0 +1,113 @@
+package com.michelet.timeslotservice.presentation.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.michelet.timeslotservice.application.service.TimeSlotService;
+import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.domain.TimeSlotStatus;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotDeductCapacityRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean; // ⭐ Spring Boot 3.4+ 최신 어노테이션
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * TimeSlotController의 웹 계층(Presentation Layer)을 독립적으로 검증하는 슬라이스 테스트(Slice Test) 클래스입니다.
+ * <p>
+ * 비즈니스 로직(Service)은 MockitoBean으로 대체(Mocking)하여,
+ * HTTP 요청/응답 라우팅, JSON 직렬화/역직렬화, HTTP 상태 코드 및 공통 응답 규격(ApiResponse)이 
+ * API 명세서대로 정확히 동작하는지 검증하는 데 목적이 있습니다.
+ * </p>
+ */
+@WebMvcTest(TimeSlotController.class)
+class TimeSlotControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // 비즈니스 로직의 실제 동작을 배제하고, 컨트롤러의 동작만 테스트하기 위한 가짜(Mock) 객체
+    @MockitoBean
+    private TimeSlotService timeSlotService;
+
+    /**
+     * [조회 API 테스트]
+     * 클라이언트가 올바른 파라미터(restaurantId, targetDate)를 전달했을 때,
+     * 컨트롤러가 서비스 계층을 정상 호출하고, 반환된 데이터를 공통 ApiResponse 포맷(200 OK)으로 응답하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("특정 식당/날짜의 타임슬롯 목록을 조회하면 200 상태코드와 ApiResponse 규격으로 반환된다.")
+    void getTimeSlots_Success() throws Exception {
+        // Given (테스트를 위한 사전 데이터 세팅)
+        UUID restaurantId = UUID.randomUUID();
+        LocalDate targetDate = LocalDate.of(2026, 5, 2);
+        UUID timeSlotId = UUID.randomUUID();
+        
+        TimeSlot mockTimeSlot = TimeSlot.builder()
+                .id(timeSlotId)
+                .restaurantId(restaurantId)
+                .targetDate(targetDate)
+                .startTime(LocalTime.of(12, 0))
+                .endTime(LocalTime.of(13, 0))
+                .capacity(4)
+                .remainingCapacity(4)
+                .status(TimeSlotStatus.OPENED)
+                .build();
+
+        // 서비스가 호출되면 가짜 데이터(mockTimeSlot)를 반환하도록 조작
+        when(timeSlotService.getTimeSlotsByDate(restaurantId, targetDate))
+                .thenReturn(List.of(mockTimeSlot));
+
+        // When & Then (실제 API 호출 및 결과 검증)
+        mockMvc.perform(get("/api/v1/timeslots")
+                        .param("restaurantId", restaurantId.toString())
+                        .param("targetDate", targetDate.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("TS_OK_001"))
+                .andExpect(jsonPath("$.data[0].id").value(timeSlotId.toString()));
+    }
+
+    /**
+     * [차감 API 테스트]
+     * 클라이언트가 올바른 JSON Body(DeductRequest)를 전달했을 때,
+     * 컨트롤러가 정상적으로 파싱하여 서비스를 호출하고, 성공 응답(200 OK)을 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("타임슬롯 예약을 차감하면 200 상태코드와 성공 메시지가 반환된다.")
+    void deductCapacity_Success() throws Exception {
+        // Given (테스트를 위한 사전 데이터 세팅)
+        UUID timeSlotId = UUID.randomUUID();
+        TimeSlotDeductCapacityRequest request = new TimeSlotDeductCapacityRequest(2);
+        
+        // 서비스 메서드가 void이므로 호출 시 아무 일도 하지 않도록 설정
+        doNothing().when(timeSlotService).deductCapacity(eq(timeSlotId), any(Integer.class));
+
+        // When & Then (실제 API 호출 및 결과 검증)
+        mockMvc.perform(post("/api/v1/timeslots/{timeSlotId}/deduct", timeSlotId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("TS_OK_002"));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 외부 클라이언트와 통신하기 위한 REST API 엔드포인트 개방 및 데이터 전송 객체(DTO) 매핑.

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #12   \

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="832" height="640" alt="image" src="https://github.com/user-attachments/assets/b5e7595c-87c9-4d57-b48f-c8015a92628a" />
<br><br>
<img width="666" height="589" alt="image" src="https://github.com/user-attachments/assets/76e5aeaa-b5e0-444a-ae02-ecbd189bca2a" />
<br><br>
<img width="662" height="563" alt="image" src="https://github.com/user-attachments/assets/cacdef5b-5ea5-43a7-9a75-8955450bb1c2" />
<br><br>
<img width="1391" height="370" alt="image" src="https://github.com/user-attachments/assets/dd19dc79-da41-4e5e-bb16-df37a50e251f" />

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 레스토랑·일자의 타임슬롯 조회 API 추가
  * 타임슬롯 예약 시 용량 차감 처리 API 추가
  * 성공 응답 코드 및 메시지 추가

* **데이터 전송 객체**
  * 조회 응답 및 차감 요청을 위한 전용 DTO 추가

* **테스트**
  * 위 API 엔드포인트 동작 검증을 위한 단위/웹 계층 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->