### PR TITLE
[FEAT] 타임슬롯 일괄 생성 (Bulk Create) API 구현

### DIFF
--- a/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
+++ b/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
@@ -3,9 +3,9 @@ package com.michelet.timeslotservice.application.service;
 import com.michelet.common.exception.BusinessException;
 import com.michelet.timeslotservice.domain.TimeSlot;
 import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
-import com.michelet.timeslotservice.infrastructure.config.persistence.TimeSlotRepository;
-import com.michelet.timeslotservice.infrastructure.config.persistence.entity.TimeSlotEntity;
-import com.michelet.timeslotservice.infrastructure.config.persistence.mapper.TimeSlotMapper;
+import com.michelet.timeslotservice.infrastructure.persistence.TimeSlotRepository;
+import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
+import com.michelet.timeslotservice.infrastructure.persistence.mapper.TimeSlotMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
+++ b/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
@@ -123,7 +123,15 @@ public class TimeSlotService {
         }
 
         if (!entitiesToSave.isEmpty()) {
-            timeSlotRepository.saveAll(entitiesToSave);
+            try {
+
+                timeSlotRepository.saveAll(entitiesToSave); 
+
+            } catch (org.springframework.dao.DataIntegrityViolationException e) {
+
+                throw new BusinessException(TimeSlotErrorCode.DUPLICATE_TIME_SLOT);
+                
+            }
         }
     }
 

--- a/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
+++ b/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
@@ -2,10 +2,12 @@ package com.michelet.timeslotservice.application.service;
 
 import com.michelet.common.exception.BusinessException;
 import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.domain.TimeSlotStatus;
 import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
 import com.michelet.timeslotservice.infrastructure.persistence.TimeSlotRepository;
 import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
 import com.michelet.timeslotservice.infrastructure.persistence.mapper.TimeSlotMapper;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotBulkCreateRequest;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,12 +15,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- * 타임슬롯과 관련된 핵심 비즈니스 로직을 처리하는 서비스 클래스.
+ * 타임슬롯과 관련된 핵심 비즈니스 로직을 처리하는 서비스 계층.
+ * 프레젠테이션 계층(Controller)과 영속성 계층(Repository) 사이에서 도메인 규칙을 조율합니다.
  */
 @Slf4j
 @Service
@@ -28,22 +34,27 @@ public class TimeSlotService {
     private final TimeSlotRepository timeSlotRepository;
     private final TimeSlotMapper timeSlotMapper;
 
-
     /**
      * 특정 식당의 지정된 날짜(TargetDate)에 해당하는 전체 타임슬롯 목록을 조회합니다.
-     * (클라이언트 화면에서 마감된 슬롯을 비활성화 처리할 수 있도록 CLOSED 상태도 포함하여 반환)
+     * 
+     * @param restaurantId 식당 식별자
+     * @param targetDate 조회하고자 하는 기준 날짜
+     * @return 검증된 순수 도메인(TimeSlot) 객체 리스트
      */
     @Transactional(readOnly = true)
     public List<TimeSlot> getTimeSlotsByDate(UUID restaurantId, LocalDate targetDate) { 
         return timeSlotRepository.findAllByRestaurantIdAndTargetDate(restaurantId, targetDate)
                 .stream()
-                .map(timeSlotMapper::toDomain)
+                .map(timeSlotMapper::toDomain) // DB 데이터를 순수 도메인으로 번역하여 컨트롤러에 반환
                 .collect(Collectors.toList());
     }
 
     /**
      * 특정 타임슬롯의 예약 가능 인원을 차감합니다.
-     * 트랜잭션 종료 시 낙관적 락(@Version)을 통해 동시성 문제를 방어합니다.
+     * 트랜잭션 종료 시 낙관적 락(@Version)을 통해 동시성(초과 예약) 문제를 방어합니다.
+     *
+     * @param timeSlotId 타임슬롯 식별자
+     * @param requiredCapacity 차감할 인원 수
      */
     @Transactional
     public void deductCapacity(UUID timeSlotId, int requiredCapacity) {
@@ -56,10 +67,64 @@ public class TimeSlotService {
         domain.deduct(requiredCapacity);
 
         TimeSlotEntity updatedEntity = timeSlotMapper.toEntity(domain);
-
         timeSlotRepository.save(updatedEntity);
         
-        log.info("타임슬롯 차감 성공: ID={}, 요청인원={}, 남은인원={}", 
-                timeSlotId, requiredCapacity, domain.getRemainingCapacity());
     }
+
+    /**
+        * 특정 식당의 타임슬롯을 일괄 생성합니다. (관리자 전용)
+        * 
+        * @param restaurantId 식당 식별자
+        * @param request      일괄 생성 조건 (날짜, 시간, 인원 등)
+     */
+    @Transactional
+    public void createTimeSlotsBulk(UUID restaurantId, TimeSlotBulkCreateRequest request) {
+
+        List<TimeSlotEntity> existingSlots = timeSlotRepository.findAllByRestaurantIdAndTargetDateBetween(
+                restaurantId, request.startDate(), request.endDate()
+        );
+
+        Set<String> existingSlotKeys = existingSlots.stream()
+                .map(slot -> slot.getTargetDate().toString() + ":" + slot.getStartTime().toString())
+                .collect(Collectors.toSet());
+
+        List<TimeSlotEntity> entitiesToSave = new ArrayList<>();
+        LocalDate currentDate = request.startDate();
+
+        while (!currentDate.isAfter(request.endDate())) {
+            LocalTime currentTime = request.openTime();
+
+            while (!currentTime.isAfter(request.closeTime())) {
+                LocalTime slotEndTime = currentTime.plusMinutes(request.intervalMinutes());
+                
+                if (slotEndTime.isAfter(request.closeTime())) {
+                    break;
+                }
+
+                String slotKey = currentDate.toString() + ":" + currentTime.toString();
+                if (existingSlotKeys.contains(slotKey)) {
+                    throw new BusinessException(TimeSlotErrorCode.DUPLICATE_TIME_SLOT);
+                }
+
+                TimeSlot newTimeSlot = TimeSlot.builder()
+                        .restaurantId(restaurantId)
+                        .targetDate(currentDate)
+                        .startTime(currentTime)
+                        .endTime(slotEndTime)
+                        .capacity(request.capacity())
+                        .remainingCapacity(request.capacity())
+                        .status(TimeSlotStatus.OPENED)
+                        .build();
+
+                entitiesToSave.add(timeSlotMapper.toEntity(newTimeSlot));
+                currentTime = slotEndTime;
+            }
+            currentDate = currentDate.plusDays(1);
+        }
+
+        if (!entitiesToSave.isEmpty()) {
+            timeSlotRepository.saveAll(entitiesToSave);
+        }
+    }
+
 }

--- a/src/main/java/com/michelet/timeslotservice/domain/exception/TimeSlotErrorCode.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/exception/TimeSlotErrorCode.java
@@ -33,7 +33,10 @@ public enum TimeSlotErrorCode implements ErrorCode {
     INVALID_DATE_RANGE("TS_007", 400, "시작일은 종료일보다 늦을 수 없습니다."),
 
     /** 중복된 타임슬롯 생성 시도 에러 */
-    DUPLICATE_TIME_SLOT("TS_008", 409, "해당 시간에 이미 생성된 타임슬롯이 존재합니다.");
+    DUPLICATE_TIME_SLOT("TS_008", 409, "해당 시간에 이미 생성된 타임슬롯이 존재합니다."),
+
+    /** 날짜 범위가 너무 큰 경우 에러 */
+    DATE_RANGE_TOO_LARGE("TS_009", 400, "날짜 범위가 너무 큽니다. 최대 31일까지 허용됩니다.");
     
 
     private final String code;

--- a/src/main/java/com/michelet/timeslotservice/domain/exception/TimeSlotErrorCode.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/exception/TimeSlotErrorCode.java
@@ -27,7 +27,14 @@ public enum TimeSlotErrorCode implements ErrorCode {
     INVALID_CAPACITY("TS_005", 400, "타임슬롯의 수용 인원 설정이 올바르지 않습니다."),
     
     /** 시간 범위 설정 오류 */
-    INVALID_TIME_RANGE("TS_006", 400, "시작 시간은 종료 시간보다 앞서야 합니다.");
+    INVALID_TIME_RANGE("TS_006", 400, "시작 시간은 종료 시간보다 앞서야 합니다."),
+
+    /** 날짜 범위 설정 오류 */
+    INVALID_DATE_RANGE("TS_007", 400, "시작일은 종료일보다 늦을 수 없습니다."),
+
+    /** 중복된 타임슬롯 생성 시도 에러 */
+    DUPLICATE_TIME_SLOT("TS_008", 409, "해당 시간에 이미 생성된 타임슬롯이 존재합니다.");
+    
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepository.java
+++ b/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepository.java
@@ -19,4 +19,9 @@ public interface TimeSlotRepository extends JpaRepository<TimeSlotEntity, UUID> 
      */
     List<TimeSlotEntity> findAllByRestaurantIdAndTargetDate(UUID restaurantId, LocalDate targetDate);
 
+    /**
+     *  특정 식당의 특정 기간 내 타임슬롯을 모두 조회합니다.
+     */ 
+    List<TimeSlotEntity> findAllByRestaurantIdAndTargetDateBetween(UUID restaurantId, LocalDate startDate, LocalDate endDate);
+
 }

--- a/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepository.java
+++ b/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepository.java
@@ -1,8 +1,8 @@
-package com.michelet.timeslotservice.infrastructure.config.persistence;
+package com.michelet.timeslotservice.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.michelet.timeslotservice.infrastructure.config.persistence.entity.TimeSlotEntity;
+import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/entity/TimeSlotEntity.java
+++ b/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/entity/TimeSlotEntity.java
@@ -1,4 +1,4 @@
-package com.michelet.timeslotservice.infrastructure.config.persistence.entity;
+package com.michelet.timeslotservice.infrastructure.persistence.entity;
 
 import com.michelet.common.entity.BaseEntity;
 import com.michelet.timeslotservice.domain.TimeSlotStatus;

--- a/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/entity/TimeSlotEntity.java
+++ b/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/entity/TimeSlotEntity.java
@@ -16,12 +16,20 @@ import java.util.UUID;
  * DB의 p_time_slot 테이블과 매핑되는 JPA 엔티티 클래스.
  */
 @Entity
-@Table(name = "p_time_slot")
+@Table(name = "p_time_slot", 
+       uniqueConstraints = {
+           @UniqueConstraint(
+               name = "uk_time_slot_restaurant_date_start", 
+               columnNames = {"restaurant_id", "target_date", "start_time"}
+           )
+       }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimeSlotEntity extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "time_slot_id")
     private UUID id;
 

--- a/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/mapper/TimeSlotMapper.java
+++ b/src/main/java/com/michelet/timeslotservice/infrastructure/persistence/mapper/TimeSlotMapper.java
@@ -1,7 +1,7 @@
-package com.michelet.timeslotservice.infrastructure.config.persistence.mapper;
+package com.michelet.timeslotservice.infrastructure.persistence.mapper;
 
 import com.michelet.timeslotservice.domain.TimeSlot;
-import com.michelet.timeslotservice.infrastructure.config.persistence.entity.TimeSlotEntity;
+import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;

--- a/src/main/java/com/michelet/timeslotservice/presentation/code/TimeSlotSuccessCode.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/code/TimeSlotSuccessCode.java
@@ -8,7 +8,8 @@ import com.michelet.common.response.SuccessCode;
 public enum TimeSlotSuccessCode implements SuccessCode {
     
     INQUIRY_SUCCESS("TS_OK_001", "타임슬롯 조회가 완료되었습니다."),
-    DEDUCT_SUCCESS("TS_OK_002", "타임슬롯 예약 차감이 완료되었습니다.");
+    DEDUCT_SUCCESS("TS_OK_002", "타임슬롯 예약 차감이 완료되었습니다."),
+    BULK_CREATE_SUCCESS("TS_OK_003", "타임슬롯 일괄 생성이 완료되었습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalController.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalController.java
@@ -7,25 +7,38 @@ import java.util.stream.Collectors;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.michelet.common.exception.BusinessException;
 import com.michelet.common.response.ApiResponse;
 import com.michelet.timeslotservice.application.service.TimeSlotService;
+import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
 import com.michelet.timeslotservice.presentation.code.TimeSlotSuccessCode;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotBulkCreateRequest;
 import com.michelet.timeslotservice.presentation.dto.response.TimeSlotResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 프론트엔드(웹/앱) 클라이언트와 통신하는 외부 공개용 API 컨트롤러.
+ */
 @RestController
-@RequestMapping("/api/v1/timeslots")
+@RequestMapping("/api/v1") 
 @RequiredArgsConstructor
 public class TimeSlotExternalController {
 
     private final TimeSlotService timeSlotService;
     
-    @GetMapping
+    /**
+     * 특정 식당/날짜의 타임슬롯 목록을 조회합니다.
+     */
+    @GetMapping("/timeslots")
     public ApiResponse<List<TimeSlotResponse>> getTimeSlots(
             @RequestParam UUID restaurantId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate) {
@@ -37,4 +50,29 @@ public class TimeSlotExternalController {
 
         return ApiResponse.ok(TimeSlotSuccessCode.INQUIRY_SUCCESS, responses);
     }
+
+    /**
+     * 특정 식당의 타임슬롯을 일괄 생성합니다. (관리자 전용)
+     * 
+     * @param restaurantId 식당 식별자
+     * @param request      일괄 생성 조건 (날짜, 시간, 인원 등)
+     */
+
+    @PostMapping("/restaurants/{restaurantId}/time-slots/bulk")
+    public ApiResponse<Void> createTimeSlotsBulk(
+            @PathVariable UUID restaurantId,
+            @Valid @RequestBody TimeSlotBulkCreateRequest request) {
+        
+        if (!request.isValidDateRange()) {
+            throw new BusinessException(TimeSlotErrorCode.INVALID_DATE_RANGE);
+        }
+        if (!request.isValidTimeRange()) {
+            throw new BusinessException(TimeSlotErrorCode.INVALID_TIME_RANGE);
+        }
+
+        timeSlotService.createTimeSlotsBulk(restaurantId, request);
+        
+        return ApiResponse.ok(TimeSlotSuccessCode.BULK_CREATE_SUCCESS, null);
+    }
+    
 }

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotBulkCreateRequest.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotBulkCreateRequest.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import com.michelet.common.exception.BusinessException;
+import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
+
 /**
  * 관리자의 타임슬롯 일괄 생성 요청 데이터를 담는 DTO
  */
@@ -36,10 +39,14 @@ public record TimeSlotBulkCreateRequest(
      * 시작일이 종료일보다 늦지 않은지 검증합니다. (Null-safe 방어 추가)
      */
     public boolean isValidDateRange() {
-        if (startDate == null || endDate == null) {
-            return false; 
+        if (startDate == null || endDate == null) return false;
+        if (startDate.isAfter(endDate)) return false;
+
+        long daysBetween = java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate);
+        if (daysBetween > 31) {
+            throw new BusinessException(TimeSlotErrorCode.DATE_RANGE_TOO_LARGE);
         }
-        return !startDate.isAfter(endDate);
+        return true;
     }
 
     /**
@@ -51,4 +58,6 @@ public record TimeSlotBulkCreateRequest(
         }
         return openTime.isBefore(closeTime);
     }
+
+    
 }

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotBulkCreateRequest.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotBulkCreateRequest.java
@@ -1,0 +1,54 @@
+package com.michelet.timeslotservice.presentation.dto.request;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 관리자의 타임슬롯 일괄 생성 요청 데이터를 담는 DTO
+ */
+public record TimeSlotBulkCreateRequest(
+
+        @NotNull(message = "시작일은 필수입니다.")
+        @FutureOrPresent(message = "시작일은 과거일 수 없습니다.")
+        LocalDate startDate,
+
+        @NotNull(message = "종료일은 필수입니다.")
+        LocalDate endDate,
+
+        @NotNull(message = "영업 시작 시간은 필수입니다.")
+        LocalTime openTime,
+
+        @NotNull(message = "영업 종료 시간은 필수입니다.")
+        LocalTime closeTime,
+
+        @NotNull(message = "슬롯 간격은 필수입니다.")
+        @Min(value = 10, message = "슬롯 간격은 최소 10분 이상이어야 합니다.")
+        Integer intervalMinutes,
+
+        @NotNull(message = "수용 인원은 필수입니다.")
+        @Min(value = 1, message = "수용 인원은 최소 1명 이상이어야 합니다.")
+        Integer capacity
+) {
+    /**
+     * 시작일이 종료일보다 늦지 않은지 검증합니다. (Null-safe 방어 추가)
+     */
+    public boolean isValidDateRange() {
+        if (startDate == null || endDate == null) {
+            return false; 
+        }
+        return !startDate.isAfter(endDate);
+    }
+
+    /**
+     * 영업 오픈 시간이 종료 시간보다 빠른지 검증합니다. (Null-safe 방어 추가)
+     */
+    public boolean isValidTimeRange() {
+        if (openTime == null || closeTime == null) {
+            return false;
+        }
+        return openTime.isBefore(closeTime);
+    }
+}

--- a/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceTest.java
+++ b/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceTest.java
@@ -3,9 +3,9 @@ package com.michelet.timeslotservice.application.service;
 import com.michelet.common.exception.BusinessException;
 import com.michelet.timeslotservice.domain.TimeSlot;
 import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
-import com.michelet.timeslotservice.infrastructure.config.persistence.TimeSlotRepository;
-import com.michelet.timeslotservice.infrastructure.config.persistence.entity.TimeSlotEntity;
-import com.michelet.timeslotservice.infrastructure.config.persistence.mapper.TimeSlotMapper;
+import com.michelet.timeslotservice.infrastructure.persistence.TimeSlotRepository;
+import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
+import com.michelet.timeslotservice.infrastructure.persistence.mapper.TimeSlotMapper;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceTest.java
+++ b/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceTest.java
@@ -6,21 +6,27 @@ import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
 import com.michelet.timeslotservice.infrastructure.persistence.TimeSlotRepository;
 import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
 import com.michelet.timeslotservice.infrastructure.persistence.mapper.TimeSlotMapper;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotBulkCreateRequest;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
 import static com.michelet.timeslotservice.support.fixture.TimeSlotFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -49,7 +55,7 @@ class TimeSlotServiceTest {
     @Test
     @DisplayName("특정 식당과 날짜의 예약 가능한 타임슬롯 목록을 정상적으로 조회한다.")
     void getAvailableTimeSlots_Success() {
-        // Given: 가짜 Repository가 반환할 대본(Stubbing)을 설정합니다.
+
         TimeSlotEntity entity = createEntity(4, 4);
         TimeSlot domain = createDomain(4, 4);
 
@@ -57,10 +63,8 @@ class TimeSlotServiceTest {
                 .willReturn(List.of(entity));
         given(timeSlotMapper.toDomain(entity)).willReturn(domain);
 
-        // When: 실제 서비스의 조회 로직을 실행합니다.
         List<TimeSlot> result = timeSlotService.getTimeSlotsByDate(FIXTURE_RESTAURANT_ID, FIXTURE_DATE);
 
-        // Then: 반환된 결과의 크기와 데이터가 정확한지 단언(Assert)합니다.
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getRestaurantId()).isEqualTo(FIXTURE_RESTAURANT_ID);
     }
@@ -72,7 +76,6 @@ class TimeSlotServiceTest {
     @Test
     @DisplayName("타임슬롯의 수용 인원을 정상적으로 차감한다.")
     void deductCapacity_Success() {
-        // Given: 차감 전 상태(4명)와 차감 후 상태(2명)의 데이터를 준비하고 대본을 짭니다.
         TimeSlotEntity entity = createEntity(4, 4);
         TimeSlot domain = createDomain(4, 4);
         TimeSlotEntity updatedEntity = createEntity(4, 2);
@@ -81,11 +84,8 @@ class TimeSlotServiceTest {
         given(timeSlotMapper.toDomain(entity)).willReturn(domain);
         given(timeSlotMapper.toEntity(domain)).willReturn(updatedEntity);
 
-        // When: 2명 차감을 요청합니다.
         timeSlotService.deductCapacity(FIXTURE_ID, 2);
 
-        // Then: 도메인 객체의 인원이 2명으로 줄었는지 확인하고, 
-        // Repository의 save 메서드가 변경된 엔티티를 파라미터로 받아 호출되었는지 행위를 검증(verify)합니다.
         assertThat(domain.getRemainingCapacity()).isEqualTo(2);
         verify(timeSlotRepository).save(updatedEntity);
     }
@@ -97,10 +97,9 @@ class TimeSlotServiceTest {
     @Test
     @DisplayName("존재하지 않는 타임슬롯을 차감하려고 하면 예외가 발생한다.")
     void deductCapacity_Fail_NotFound() {
-        // Given: Repository 조회 시 빈 결과(Optional.empty)가 반환되도록 대본을 짭니다.
+
         given(timeSlotRepository.findById(FIXTURE_ID)).willReturn(Optional.empty());
 
-        // When & Then: 서비스 로직 실행 중 특정 예외(BusinessException)와 에러 메시지가 발생하는지 검증합니다.
         assertThatThrownBy(() -> timeSlotService.deductCapacity(FIXTURE_ID, 2))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(TimeSlotErrorCode.TIME_SLOT_NOT_FOUND.getMessage());
@@ -113,16 +112,77 @@ class TimeSlotServiceTest {
     @Test
     @DisplayName("잔여 인원보다 많은 인원을 차감하려고 하면 예외가 발생한다.")
     void deductCapacity_Fail_NotEnoughCapacity() {
-        // Given: 잔여 인원이 1명뿐인 타임슬롯 데이터를 준비합니다.
+
         TimeSlotEntity entity = createEntity(4, 1);
         TimeSlot domain = createDomain(4, 1);
 
         given(timeSlotRepository.findById(FIXTURE_ID)).willReturn(Optional.of(entity));
         given(timeSlotMapper.toDomain(entity)).willReturn(domain);
 
-        // When & Then: 1명 남았는데 2명을 차감하려 할 때 오버부킹 방지 예외가 터지는지 검증합니다.
+
         assertThatThrownBy(() -> timeSlotService.deductCapacity(FIXTURE_ID, 2))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(TimeSlotErrorCode.NOT_ENOUGH_CAPACITY.getMessage());
     }
+
+    /**
+     * 일괄 생성 로직 검증 (정상 흐름):
+     * 이중 루프(날짜, 시간)가 정상 작동하여, 지정된 기간과 간격에 맞는 
+     * 정확한 개수의 타임슬롯 엔티티가 Repository로 전달되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("정상적인 조건이 주어지면, 날짜와 시간을 계산하여 알맞은 개수의 타임슬롯을 일괄 생성(saveAll)한다.")
+    void createTimeSlotsBulk_Success() {
+        LocalDate startDate = LocalDate.of(2026, 5, 1);
+        LocalDate endDate = LocalDate.of(2026, 5, 2);
+        LocalTime openTime = LocalTime.of(10, 0);
+        LocalTime closeTime = LocalTime.of(11, 0);
+
+        TimeSlotBulkCreateRequest request = new TimeSlotBulkCreateRequest(
+                startDate, endDate, openTime, closeTime, 30, 4
+        );
+
+        given(timeSlotMapper.toEntity(any(TimeSlot.class)))
+                .willReturn(createEntity(4, 4));
+
+        timeSlotService.createTimeSlotsBulk(FIXTURE_RESTAURANT_ID, request);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<TimeSlotEntity>> captor = ArgumentCaptor.forClass(List.class);
+        
+        verify(timeSlotRepository, times(1)).saveAll(captor.capture());
+        
+        List<TimeSlotEntity> savedEntities = captor.getValue();
+        
+        assertThat(savedEntities).hasSize(4);
+    }
+
+    /**
+     * 일괄 생성 로직 검증
+     * 영업 마감 시간을 넘어서는 슬롯은 헬퍼 메서드에서 생성하지 않고 버리는지 검증합니다.
+     */
+    @Test
+    @DisplayName("생성될 타임슬롯의 종료 시간이 영업 마감 시간을 초과하면 해당 슬롯은 버려진다.")
+    void createTimeSlotsBulk_SkipExceedingTime() {
+
+        LocalDate targetDate = LocalDate.of(2026, 5, 1);
+        LocalTime openTime = LocalTime.of(10, 0);
+        LocalTime closeTime = LocalTime.of(10, 45);
+
+        TimeSlotBulkCreateRequest request = new TimeSlotBulkCreateRequest(
+                targetDate, targetDate, openTime, closeTime, 30, 4
+        );
+
+        given(timeSlotMapper.toEntity(any(TimeSlot.class)))
+                .willReturn(createEntity(4, 4));
+
+        timeSlotService.createTimeSlotsBulk(FIXTURE_RESTAURANT_ID, request);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<TimeSlotEntity>> captor = ArgumentCaptor.forClass(List.class);
+        verify(timeSlotRepository).saveAll(captor.capture());
+
+        assertThat(captor.getValue()).hasSize(1);
+    }
+
 }

--- a/src/test/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepositoryTest.java
+++ b/src/test/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepositoryTest.java
@@ -1,8 +1,5 @@
 package com.michelet.timeslotservice.infrastructure.persistence;
 
-import com.michelet.timeslotservice.infrastructure.config.persistence.TimeSlotRepository;
-import com.michelet.timeslotservice.infrastructure.config.persistence.entity.TimeSlotEntity;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +10,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
 
 import java.util.Optional;
 import java.util.UUID;

--- a/src/test/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepositoryTest.java
+++ b/src/test/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepositoryTest.java
@@ -16,8 +16,6 @@ import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEn
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.michelet.timeslotservice.support.fixture.TimeSlotFixture.FIXTURE_ID;
-import static com.michelet.timeslotservice.support.fixture.TimeSlotFixture.createEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -67,19 +65,23 @@ class TimeSlotRepositoryTest {
     @DisplayName("TimeSlotEntity can be saved and found by ID")
     void saveAndFindById_Success() {
         
-        // Given: 픽스처를 사용하여 검증에 필요한 최소한의 엔티티 객체를 준비합니다.
-        TimeSlotEntity entity = createEntity(4, 4);
+        TimeSlotEntity newEntity = TimeSlotEntity.builder()
 
-        // When: 데이터를 DB에 강제로 기록(Flush)하고, 영속성 컨텍스트(1차 캐시)를 초기화합니다.
-        // 이를 통해 다음 findById 호출 시 메모리가 아닌 실제 DB에서 쿼리를 통해 데이터를 가져오도록 강제합니다.
-        TimeSlotEntity saved = timeSlotRepository.saveAndFlush(entity); 
+                .restaurantId(UUID.randomUUID())
+                .targetDate(java.time.LocalDate.now())
+                .startTime(java.time.LocalTime.of(10, 0))
+                .endTime(java.time.LocalTime.of(11, 0))
+                .capacity(4)
+                .remainingCapacity(4)
+                .status(com.michelet.timeslotservice.domain.TimeSlotStatus.OPENED)
+                .build();
+
+        TimeSlotEntity saved = timeSlotRepository.saveAndFlush(newEntity); 
         entityManager.clear(); 
 
         TimeSlotEntity found = timeSlotRepository.findById(saved.getId()).orElseThrow();
 
-        // Then: DB에서 다시 꺼내온 데이터의 식별자가 일치하는지, 
-        // 그리고 JPA Auditing이 작동하여 생성 시간이 자동으로 찍혔는지 검증합니다.
-        assertThat(found.getId()).isEqualTo(FIXTURE_ID);
+        assertThat(found.getId()).isNotNull();
         assertThat(found.getCreatedAt()).isNotNull(); 
     }
 }

--- a/src/test/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepositoryTest.java
+++ b/src/test/java/com/michelet/timeslotservice/infrastructure/persistence/TimeSlotRepositoryTest.java
@@ -81,7 +81,7 @@ class TimeSlotRepositoryTest {
 
         TimeSlotEntity found = timeSlotRepository.findById(saved.getId()).orElseThrow();
 
-        assertThat(found.getId()).isNotNull();
+        assertThat(found.getId()).isEqualTo(saved.getId());
         assertThat(found.getCreatedAt()).isNotNull(); 
     }
 }

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
@@ -1,7 +1,11 @@
 package com.michelet.timeslotservice.presentation.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.michelet.common.exception.BusinessException;
 import com.michelet.timeslotservice.application.service.TimeSlotService;
 import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotBulkCreateRequest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,13 +14,21 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import static com.michelet.timeslotservice.support.fixture.TimeSlotFixture.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 /**
  * [External API Test]
@@ -36,16 +48,18 @@ class TimeSlotExternalControllerTest {
     @MockitoBean
     private TimeSlotService timeSlotService;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Test
     @DisplayName("[External] 특정 식당/날짜의 타임슬롯 목록을 조회하면 200 상태코드와 규격에 맞게 반환된다.")
     void getTimeSlots_Success() throws Exception {
-        // Given
+
         TimeSlot mockTimeSlot = createDomain(4, 4);
 
         given(timeSlotService.getTimeSlotsByDate(FIXTURE_RESTAURANT_ID, FIXTURE_DATE))
                 .willReturn(List.of(mockTimeSlot));
 
-        // When & Then
         mockMvc.perform(get("/api/v1/timeslots")
                         .param("restaurantId", FIXTURE_RESTAURANT_ID.toString())
                         .param("targetDate", FIXTURE_DATE.toString())
@@ -54,5 +68,75 @@ class TimeSlotExternalControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.code").value("TS_OK_001"))
                 .andExpect(jsonPath("$.data[0].id").value(FIXTURE_ID.toString()));
+    }
+
+    /**
+     * 프론트엔드의 타임슬롯 일괄 생성(POST) 요청이 
+     * 적절한 URL 경로를 타고 들어와 정상 응답(200 OK)을 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("[External] 타임슬롯 일괄 생성 요청 시 200 상태코드와 성공 응답 규격이 반환된다.")
+    void createTimeSlotsBulk_Success() throws Exception {
+        TimeSlotBulkCreateRequest request = new TimeSlotBulkCreateRequest(
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 5),
+                LocalTime.of(9, 0),
+                LocalTime.of(21, 0),
+                30,
+                4
+        );
+
+        willDoNothing().given(timeSlotService).createTimeSlotsBulk(eq(FIXTURE_RESTAURANT_ID), any(TimeSlotBulkCreateRequest.class));
+
+        mockMvc.perform(post("/api/v1/restaurants/{restaurantId}/time-slots/bulk", FIXTURE_RESTAURANT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("TS_OK_003")); 
+    }
+
+    /**
+     * DTO 내부의 논리적 모순(시작일이 종료일보다 늦은 경우)이 
+     * Controller 진입 시점에서 잘 차단되는지 예외를 검증합니다.
+     */
+    @Test
+    @DisplayName("[External] 시작일이 종료일보다 늦으면 Controller에서 예외가 발생한다.")
+    void createTimeSlotsBulk_Fail_InvalidDateRange() throws Exception {
+        TimeSlotBulkCreateRequest invalidRequest = new TimeSlotBulkCreateRequest(
+                LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 1),
+                LocalTime.of(9, 0), LocalTime.of(21, 0), 30, 4
+        );
+        
+        assertThatThrownBy(() ->
+                mockMvc.perform(post("/api/v1/restaurants/{restaurantId}/time-slots/bulk", FIXTURE_RESTAURANT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+        )
+        .isInstanceOf(Exception.class)
+        .hasCauseInstanceOf(BusinessException.class);
+    }
+
+    /**
+     * DTO 내부의 논리적 모순(오픈 시간이 마감 시간보다 늦은 경우)이 
+     * Controller 진입 시점에서 잘 차단되는지 예외를 검증합니다.
+     */
+    @Test
+    @DisplayName("[External] 시작 시간이 종료 시간보다 늦으면 Controller에서 예외가 발생한다.")
+    void createTimeSlotsBulk_Fail_InvalidTimeRange() throws Exception {
+
+        TimeSlotBulkCreateRequest invalidRequest = new TimeSlotBulkCreateRequest(
+                LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 5),
+                LocalTime.of(18, 0), LocalTime.of(17, 0),
+                30, 4
+        );
+
+        assertThatThrownBy(() ->
+                mockMvc.perform(post("/api/v1/restaurants/{restaurantId}/time-slots/bulk", FIXTURE_RESTAURANT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+        )
+        .isInstanceOf(Exception.class)
+        .hasCauseInstanceOf(BusinessException.class);
     }
 }

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
@@ -151,7 +151,7 @@ class TimeSlotExternalControllerTest {
 
         TimeSlotBulkCreateRequest invalidRequest = new TimeSlotBulkCreateRequest(
                 LocalDate.of(2026, 5, 1), LocalDate.of(2036, 6, 1),
-                LocalTime.of(18, 0), LocalTime.of(17, 0),
+                LocalTime.of(9, 0), LocalTime.of(21, 0),
                 30, 4
         );
 

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
@@ -139,4 +139,28 @@ class TimeSlotExternalControllerTest {
         .isInstanceOf(Exception.class)
         .hasCauseInstanceOf(BusinessException.class);
     }
+
+
+        /**
+        * DTO 내부의 논리적 모순(날짜 범위가 너무 큰 경우)이 
+        * Controller 진입 시점에서 잘 차단되는지 예외를 검증합니다.
+        */
+    @Test
+    @DisplayName("[External] 날짜 범위가 너무 크면 Controller에서 예외가 발생한다.")
+    void createTimeSlotsBulk_Fail_DateRangeTooLarge() throws Exception {
+
+        TimeSlotBulkCreateRequest invalidRequest = new TimeSlotBulkCreateRequest(
+                LocalDate.of(2026, 5, 1), LocalDate.of(2036, 6, 1),
+                LocalTime.of(18, 0), LocalTime.of(17, 0),
+                30, 4
+        );
+
+        assertThatThrownBy(() ->
+                mockMvc.perform(post("/api/v1/restaurants/{restaurantId}/time-slots/bulk", FIXTURE_RESTAURANT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+        )
+        .isInstanceOf(Exception.class)
+        .hasCauseInstanceOf(BusinessException.class);
+    }
 }

--- a/src/test/java/com/michelet/timeslotservice/support/fixture/TimeSlotFixture.java
+++ b/src/test/java/com/michelet/timeslotservice/support/fixture/TimeSlotFixture.java
@@ -2,7 +2,7 @@ package com.michelet.timeslotservice.support.fixture;
 
 import com.michelet.timeslotservice.domain.TimeSlot;
 import com.michelet.timeslotservice.domain.TimeSlotStatus;
-import com.michelet.timeslotservice.infrastructure.config.persistence.entity.TimeSlotEntity;
+import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
 
 import java.time.LocalDate;
 import java.time.LocalTime;


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 식당의 지정된 기간(시작일~종료일), 영업시간, 슬롯 간격을 설정하여 타임슬롯을 일괄 생성할 수 있는 API를 제공한다.

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #18   \


## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1341" height="265" alt="image" src="https://github.com/user-attachments/assets/3925e2d9-d4de-439a-9ec2-5c9d7f75b274" />
<br><br>
<img width="728" height="628" alt="image" src="https://github.com/user-attachments/assets/509d05da-a3f5-45c5-9d9e-8c17ff684f61" />
<br><br>
<img width="721" height="638" alt="image" src="https://github.com/user-attachments/assets/931f3af9-fc70-4178-b9f0-5d2ed733bc69" />

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시간대 일괄 생성 API 추가 — 날짜 범위와 시간 범위, 간격 및 정원 지정으로 다수 타임슬롯 일괄 생성
  * 일괄 생성 성공 코드 및 성공 응답 제공

* **버그 수정 / 개선**
  * 중복 시간대 방지 — 동일 날짜·시작시간 충돌 시 충돌 오류 반환
  * 입력 검증 강화 — 시작/종료 날짜·시간 검증 및 최대 날짜 범위(31일) 제한 적용
  * 생성된 슬롯에 정원(capacity) 초기화 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->