### PR TITLE
[FEAT] 특정 일자 시간대(타임슬롯) 조회 API

### DIFF
--- a/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalController.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalController.java
@@ -36,11 +36,11 @@ public class TimeSlotExternalController {
     private final TimeSlotService timeSlotService;
     
     /**
-     * 특정 식당/날짜의 타임슬롯 목록을 조회합니다.
+     * 특정 식당의 특정 일자(TargetDate) 타임슬롯 목록을 조회합니다.
      */
-    @GetMapping("/timeslots")
+    @GetMapping("/restaurants/{restaurantId}/time-slots")
     public ApiResponse<List<TimeSlotResponse>> getTimeSlots(
-            @RequestParam UUID restaurantId,
+            @PathVariable UUID restaurantId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate) {
 
         List<TimeSlotResponse> responses = timeSlotService.getTimeSlotsByDate(restaurantId, targetDate)

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/response/TimeSlotResponse.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/response/TimeSlotResponse.java
@@ -3,17 +3,11 @@ package com.michelet.timeslotservice.presentation.dto.response;
 import com.michelet.timeslotservice.domain.TimeSlot;
 import com.michelet.timeslotservice.domain.TimeSlotStatus;
 
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
 
-/**
- * 타임슬롯 기본 응답 DTO
- */
 public record TimeSlotResponse(
-        UUID id,
-        UUID restaurantId,
-        LocalDate targetDate,
+        UUID timeSlotId,
         LocalTime startTime,
         LocalTime endTime,
         int capacity,
@@ -23,8 +17,6 @@ public record TimeSlotResponse(
     public static TimeSlotResponse from(TimeSlot domain) {
         return new TimeSlotResponse(
                 domain.getId(),
-                domain.getRestaurantId(),
-                domain.getTargetDate(),
                 domain.getStartTime(),
                 domain.getEndTime(),
                 domain.getCapacity(),

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
@@ -51,23 +51,30 @@ class TimeSlotExternalControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    /**
+     * 프론트엔드가 특정 식당의 특정 일자 달력을 클릭했을 때 호출되는 일간 조회 API를 검증합니다.
+     * 1. RESTful 표준에 맞게 수정된 URL (/restaurants/{id}/time-slots) 라우팅을 확인합니다.
+     * 2. 프론트엔드 UI 렌더링(예약 가능/불가 색상 처리 등)에 필수적인 필드
+     * (timeSlotId, remainingCapacity, status)가 JSON 응답에 누락 없이 매핑되는지 확인합니다.
+     */
     @Test
     @DisplayName("[External] 특정 식당/날짜의 타임슬롯 목록을 조회하면 200 상태코드와 규격에 맞게 반환된다.")
     void getTimeSlots_Success() throws Exception {
-
+        
         TimeSlot mockTimeSlot = createDomain(4, 4);
 
         given(timeSlotService.getTimeSlotsByDate(FIXTURE_RESTAURANT_ID, FIXTURE_DATE))
                 .willReturn(List.of(mockTimeSlot));
 
-        mockMvc.perform(get("/api/v1/timeslots")
-                        .param("restaurantId", FIXTURE_RESTAURANT_ID.toString())
+        mockMvc.perform(get("/api/v1/restaurants/{restaurantId}/time-slots", FIXTURE_RESTAURANT_ID)
                         .param("targetDate", FIXTURE_DATE.toString())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.code").value("TS_OK_001"))
-                .andExpect(jsonPath("$.data[0].id").value(FIXTURE_ID.toString()));
+                .andExpect(jsonPath("$.data[0].timeSlotId").value(FIXTURE_ID.toString()))
+                .andExpect(jsonPath("$.data[0].remainingCapacity").value(4))
+                .andExpect(jsonPath("$.data[0].status").value("OPENED"));
     }
 
     /**
@@ -78,13 +85,13 @@ class TimeSlotExternalControllerTest {
     @DisplayName("[External] 타임슬롯 일괄 생성 요청 시 200 상태코드와 성공 응답 규격이 반환된다.")
     void createTimeSlotsBulk_Success() throws Exception {
         TimeSlotBulkCreateRequest request = new TimeSlotBulkCreateRequest(
-                LocalDate.of(2026, 5, 1),
-                LocalDate.of(2026, 5, 5),
-                LocalTime.of(9, 0),
-                LocalTime.of(21, 0),
-                30,
-                4
-        );
+            LocalDate.of(2099, 5, 10),
+            LocalDate.of(2099, 5, 15),
+            LocalTime.of(9, 0),
+            LocalTime.of(21, 0),
+            30,
+            4
+    );
 
         willDoNothing().given(timeSlotService).createTimeSlotsBulk(eq(FIXTURE_RESTAURANT_ID), any(TimeSlotBulkCreateRequest.class));
 
@@ -104,7 +111,7 @@ class TimeSlotExternalControllerTest {
     @DisplayName("[External] 시작일이 종료일보다 늦으면 Controller에서 예외가 발생한다.")
     void createTimeSlotsBulk_Fail_InvalidDateRange() throws Exception {
         TimeSlotBulkCreateRequest invalidRequest = new TimeSlotBulkCreateRequest(
-                LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 1),
+                LocalDate.of(2099, 5, 5), LocalDate.of(2099, 5, 1),
                 LocalTime.of(9, 0), LocalTime.of(21, 0), 30, 4
         );
         
@@ -126,7 +133,7 @@ class TimeSlotExternalControllerTest {
     void createTimeSlotsBulk_Fail_InvalidTimeRange() throws Exception {
 
         TimeSlotBulkCreateRequest invalidRequest = new TimeSlotBulkCreateRequest(
-                LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 5),
+                LocalDate.of(2099, 5, 1), LocalDate.of(2099, 5, 5),
                 LocalTime.of(18, 0), LocalTime.of(17, 0),
                 30, 4
         );
@@ -150,8 +157,8 @@ class TimeSlotExternalControllerTest {
     void createTimeSlotsBulk_Fail_DateRangeTooLarge() throws Exception {
 
         TimeSlotBulkCreateRequest invalidRequest = new TimeSlotBulkCreateRequest(
-                LocalDate.of(2026, 5, 1), LocalDate.of(2036, 6, 1),
-                LocalTime.of(9, 0), LocalTime.of(21, 0),
+                LocalDate.of(2099, 5, 1), LocalDate.of(2099, 6, 22),
+                LocalTime.of(18, 0), LocalTime.of(21, 0),
                 30, 4
         );
 

--- a/src/test/java/com/michelet/timeslotservice/support/fixture/TimeSlotFixture.java
+++ b/src/test/java/com/michelet/timeslotservice/support/fixture/TimeSlotFixture.java
@@ -27,7 +27,7 @@ public class TimeSlotFixture {
     public static final UUID FIXTURE_RESTAURANT_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
     
     /** 고정된 타겟 날짜 (테스트 기준일). */
-    public static final LocalDate FIXTURE_DATE = LocalDate.of(2026, 5, 2);
+    public static final LocalDate FIXTURE_DATE = LocalDate.of(2099, 12, 1);
     
     /** 고정된 시작 시간. */
     public static final LocalTime FIXTURE_START_TIME = LocalTime.of(12, 0);


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 특정 일자 시간대(타임슬롯) 조회 API 작성 및 테스트 케이스 작성

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #20   \

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1341" height="258" alt="image" src="https://github.com/user-attachments/assets/2aee63c5-b8ff-4397-be48-006f0bb33a69" />
<br><br>
<img width="837" height="891" alt="image" src="https://github.com/user-attachments/assets/18e294e5-54d0-43f1-9941-6b11816bd82e" />



---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **API 변경**
  * 시간대 조회 엔드포인트의 REST 경로 구조를 개선하였습니다
  * 시간대 응답 데이터 구조를 단순화하여 불필요한 필드를 제거했습니다
  * API의 일관성을 향상시키기 위해 식별자 필드명을 통일했습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->