### PR TITLE
[FEAT] 월간 타임슬롯 달력 조회 API 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
+++ b/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
@@ -8,6 +8,7 @@ import com.michelet.timeslotservice.infrastructure.persistence.TimeSlotRepositor
 import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
 import com.michelet.timeslotservice.infrastructure.persistence.mapper.TimeSlotMapper;
 import com.michelet.timeslotservice.presentation.dto.request.TimeSlotBulkCreateRequest;
+import com.michelet.timeslotservice.presentation.dto.response.TimeSlotCalendarResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -133,6 +134,42 @@ public class TimeSlotService {
                 
             }
         }
+    }
+
+
+    /**
+     * 특정 식당의 특정 연/월 달력(예약 가능 여부)을 조회합니다.
+     * * @param restaurantId 식당 식별자
+     * @param year         조회 연도
+     * @param month        조회 월
+     * @return 일자별 예약 가능 상태 목록 (1일부터 말일까지 빠짐없이 반환)
+     */
+    @Transactional(readOnly = true)
+    public List<TimeSlotCalendarResponse> getCalendarByMonth(UUID restaurantId, int year, int month) {
+        
+        java.time.YearMonth yearMonth = java.time.YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        List<TimeSlotEntity> monthlySlots = timeSlotRepository.findAllByRestaurantIdAndTargetDateBetween(
+                restaurantId, startDate, endDate
+        );
+
+        java.util.Map<LocalDate, List<TimeSlotEntity>> slotsByDate = monthlySlots.stream()
+                .collect(Collectors.groupingBy(TimeSlotEntity::getTargetDate));
+
+        List<TimeSlotCalendarResponse> calendar = new ArrayList<>();
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            
+            List<TimeSlotEntity> dailySlots = slotsByDate.getOrDefault(date, java.util.Collections.emptyList());
+            
+            boolean isOpened = dailySlots.stream()
+                    .anyMatch(slot -> slot.getStatus() == TimeSlotStatus.OPENED);
+            
+            calendar.add(TimeSlotCalendarResponse.of(date, isOpened));
+        }
+
+        return calendar;
     }
 
 }

--- a/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalController.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,6 +25,8 @@ import com.michelet.timeslotservice.presentation.dto.response.TimeSlotCalendarRe
 import com.michelet.timeslotservice.presentation.dto.response.TimeSlotResponse;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -32,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1") 
 @RequiredArgsConstructor
+@Validated
 public class TimeSlotExternalController {
 
     private final TimeSlotService timeSlotService;
@@ -82,8 +86,8 @@ public class TimeSlotExternalController {
     @GetMapping("/restaurants/{restaurantId}/time-slots/calendar")
     public ApiResponse<List<TimeSlotCalendarResponse>> getCalendarByMonth(
             @PathVariable UUID restaurantId,
-            @RequestParam int year,
-            @RequestParam int month) {
+            @RequestParam @Min(2024) int year,
+            @RequestParam @Min(1) @Max(12) int month) {
 
         List<TimeSlotCalendarResponse> responses = timeSlotService.getCalendarByMonth(restaurantId, year, month);
 

--- a/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalController.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalController.java
@@ -20,6 +20,7 @@ import com.michelet.timeslotservice.application.service.TimeSlotService;
 import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
 import com.michelet.timeslotservice.presentation.code.TimeSlotSuccessCode;
 import com.michelet.timeslotservice.presentation.dto.request.TimeSlotBulkCreateRequest;
+import com.michelet.timeslotservice.presentation.dto.response.TimeSlotCalendarResponse;
 import com.michelet.timeslotservice.presentation.dto.response.TimeSlotResponse;
 
 import jakarta.validation.Valid;
@@ -75,4 +76,17 @@ public class TimeSlotExternalController {
         return ApiResponse.ok(TimeSlotSuccessCode.BULK_CREATE_SUCCESS, null);
     }
     
+    /**
+     * 특정 식당의 월간 달력(예약 가능 여부)을 조회합니다.
+     */
+    @GetMapping("/restaurants/{restaurantId}/time-slots/calendar")
+    public ApiResponse<List<TimeSlotCalendarResponse>> getCalendarByMonth(
+            @PathVariable UUID restaurantId,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        List<TimeSlotCalendarResponse> responses = timeSlotService.getCalendarByMonth(restaurantId, year, month);
+
+        return ApiResponse.ok(TimeSlotSuccessCode.INQUIRY_SUCCESS, responses);
+    }
 }

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/response/TimeSlotCalendarResponse.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/response/TimeSlotCalendarResponse.java
@@ -1,0 +1,16 @@
+package com.michelet.timeslotservice.presentation.dto.response;
+
+import java.time.LocalDate;
+
+
+/**
+ * 프론트엔드의 월간 달력 UI에 필요한 날짜별 예약 가능 여부 정보를 담는 DTO입니다.
+ */
+public record TimeSlotCalendarResponse(
+        LocalDate date,
+        String status
+) {
+    public static TimeSlotCalendarResponse of(LocalDate date, boolean isOpened) {
+        return new TimeSlotCalendarResponse(date, isOpened ? "OPENED" : "CLOSED");
+    }
+}

--- a/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceTest.java
+++ b/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceTest.java
@@ -2,6 +2,7 @@ package com.michelet.timeslotservice.application.service;
 
 import com.michelet.common.exception.BusinessException;
 import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.domain.TimeSlotStatus;
 import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
 import com.michelet.timeslotservice.infrastructure.persistence.TimeSlotRepository;
 import com.michelet.timeslotservice.infrastructure.persistence.entity.TimeSlotEntity;
@@ -183,6 +184,44 @@ class TimeSlotServiceTest {
         verify(timeSlotRepository).saveAll(captor.capture());
 
         assertThat(captor.getValue()).hasSize(1);
+    }
+
+    /**
+     * 월간 달력 조회 로직 검증:
+     * 1. DB에 데이터가 있든 없든 1일부터 말일까지의 날짜 리스트가 꽉 채워져 반환되는지 확인합니다.
+     * 2. 해당 일자에 하나라도 OPENED 슬롯이 있으면 "OPENED", 모두 CLOSED이거나 데이터가 없으면 "CLOSED"로 정확히 집계되는지 검증합니다.
+     */
+    @Test
+    @DisplayName("특정 연/월 달력 조회 시 1일부터 말일까지의 예약 상태가 정확히 집계된다.")
+    void getCalendarByMonth_Success() {
+        int year = 2099;
+        int month = 5;
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = LocalDate.of(year, month, 31);
+
+        TimeSlotEntity openSlot = org.mockito.Mockito.mock(TimeSlotEntity.class);
+        given(openSlot.getTargetDate()).willReturn(LocalDate.of(2099, 5, 1));
+        given(openSlot.getStatus()).willReturn(TimeSlotStatus.OPENED);
+
+        TimeSlotEntity closedSlot = org.mockito.Mockito.mock(TimeSlotEntity.class);
+        given(closedSlot.getTargetDate()).willReturn(LocalDate.of(2099, 5, 2));
+        given(closedSlot.getStatus()).willReturn(TimeSlotStatus.CLOSED);
+
+        given(timeSlotRepository.findAllByRestaurantIdAndTargetDateBetween(FIXTURE_RESTAURANT_ID, startDate, endDate))
+                .willReturn(List.of(openSlot, closedSlot));
+
+        var result = timeSlotService.getCalendarByMonth(FIXTURE_RESTAURANT_ID, year, month);
+
+        assertThat(result).hasSize(31);
+        
+        assertThat(result.get(0).date()).isEqualTo(LocalDate.of(2099, 5, 1));
+        assertThat(result.get(0).status()).isEqualTo("OPENED");
+
+        assertThat(result.get(1).date()).isEqualTo(LocalDate.of(2099, 5, 2));
+        assertThat(result.get(1).status()).isEqualTo("CLOSED");
+
+        assertThat(result.get(2).date()).isEqualTo(LocalDate.of(2099, 5, 3));
+        assertThat(result.get(2).status()).isEqualTo("CLOSED");
     }
 
 }

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
@@ -5,6 +5,7 @@ import com.michelet.common.exception.BusinessException;
 import com.michelet.timeslotservice.application.service.TimeSlotService;
 import com.michelet.timeslotservice.domain.TimeSlot;
 import com.michelet.timeslotservice.presentation.dto.request.TimeSlotBulkCreateRequest;
+import com.michelet.timeslotservice.presentation.dto.response.TimeSlotCalendarResponse;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -169,5 +170,35 @@ class TimeSlotExternalControllerTest {
         )
         .isInstanceOf(Exception.class)
         .hasCauseInstanceOf(BusinessException.class);
+    }
+
+
+    /**
+     * 프론트엔드의 월간 달력 조회(GET) 요청이 
+     * 적절한 URL 경로와 파라미터를 타고 들어와 정상 응답(200 OK)과 달력 데이터를 반환하는지 검증합니다.
+     */
+    @Test
+    @DisplayName("[External] 특정 식당의 월간 달력 조회 시 200 상태코드와 규격에 맞는 데이터가 반환된다.")
+    void getCalendarByMonth_Success() throws Exception {
+        int year = 2099;
+        int month = 5;
+        
+        TimeSlotCalendarResponse responseDay1 = new TimeSlotCalendarResponse(LocalDate.of(year, month, 1), "OPENED");
+        TimeSlotCalendarResponse responseDay2 = new TimeSlotCalendarResponse(LocalDate.of(year, month, 2), "CLOSED");
+        
+        given(timeSlotService.getCalendarByMonth(FIXTURE_RESTAURANT_ID, year, month))
+                .willReturn(List.of(responseDay1, responseDay2));
+
+        mockMvc.perform(get("/api/v1/restaurants/{restaurantId}/time-slots/calendar", FIXTURE_RESTAURANT_ID)
+                        .param("year", String.valueOf(year))
+                        .param("month", String.valueOf(month))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("TS_OK_001"))
+                .andExpect(jsonPath("$.data[0].date").value("2099-05-01"))
+                .andExpect(jsonPath("$.data[0].status").value("OPENED"))
+                .andExpect(jsonPath("$.data[1].date").value("2099-05-02"))
+                .andExpect(jsonPath("$.data[1].status").value("CLOSED"));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 식당 상세 페이지의 달력 UI 렌더링을 위해, 특정 연/월의 일자별 예약 가능 여부(OPENED/CLOSED)를 집계하여 반환하는 API를 구현 및 테스트 코드 작성

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #22   \

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1325" height="260" alt="image" src="https://github.com/user-attachments/assets/9dc455cb-ca7c-4d6c-a4f2-9bcd2514841f" />

<br><br>

<img width="869" height="754" alt="image" src="https://github.com/user-attachments/assets/75aa482f-f14c-498c-a131-5a145bcb9170" />



---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 식당 월간 타임슬롯 캘린더 조회 API 추가: 특정 연도/월에 대해 1일~말일까지 일별 예약 가능 여부(OPENED/CLOSED)를 반환하며 연도·월 입력 검증을 수행합니다.
* **Tests**
  * 월간 캘린더 생성 로직과 해당 API 응답을 검증하는 단위/외부 테스트 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->