### PR TITLE
[DOCS] TimeSlot 서비스 API 명세화 (.http 파일 및 Spring REST Docs 적용)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.14'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.michelet'
@@ -13,6 +14,14 @@ java {
 	}
 }
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    // 2. Asciidoctor 확장 설정 추가
+    asciidoctorExt
+}
+
 repositories {
 	mavenCentral()
 	maven { url 'https://jitpack.io' }
@@ -20,6 +29,7 @@ repositories {
 
 ext {
 	set('springCloudVersion', "2025.0.2")
+	snippetsDir = file('build/generated-snippets')
 }
 
 dependencies {
@@ -37,10 +47,34 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+}
+
+test {
+    outputs.dir snippetsDir
+    useJUnitPlatform()
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
+
+    attributes 'snippets': snippetsDir
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from ("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }
 
 dependencyManagement {

--- a/http/timeslot-api.http
+++ b/http/timeslot-api.http
@@ -1,0 +1,28 @@
+### 환경 변수 설정
+@host = http://localhost:19400
+@restaurantId = d4246628-b7da-47ab-95bb-a126395f0628
+@X-User-Id = 550e8400-e29b-41d4-a716-446655440000
+@X-User-Role = OWNER
+### 1. [외부 API] 특정 날짜의 타임슬롯 목록 조회
+GET {{host}}/api/v1/restaurants/{{restaurantId}}/time-slots?targetDate=2026-05-31
+Accept: application/json
+
+### 2. [외부 API] 타임슬롯 일괄 생성 (관리자 전용)
+POST {{host}}/api/v1/restaurants/{{restaurantId}}/time-slots/bulk
+Content-Type: application/json
+X-User-Id: {{X-User-Id}}
+X-User-Role: {{X-User-Role}}
+
+
+{
+  "startDate": "2026-05-05",
+  "endDate": "2026-05-10",
+  "openTime": "10:00:00",
+  "closeTime": "22:00:00",
+  "intervalMinutes": 60,
+  "capacity": 4
+}
+
+### 3. [외부 API] 월간 달력(예약 가능 여부) 조회
+GET {{host}}/api/v1/restaurants/{{restaurantId}}/time-slots/calendar?year=2026&month=5
+Accept: application/json

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,57 @@
+= TimeSlot Service API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:snippets: {snippets}
+
+[[TimeSlot-API]]
+== 타임슬롯(TimeSlot) 도메인 API
+
+---
+
+[[timeslot-get-list]]
+=== 1. 타임슬롯 목록 조회
+특정 식당의 특정 일자 타임슬롯 목록을 조회합니다.
+
+==== 요청 (Request)
+include::{snippets}/timeslot-get-list/http-request.adoc[]
+include::{snippets}/timeslot-get-list/path-parameters.adoc[]
+include::{snippets}/timeslot-get-list/query-parameters.adoc[]
+
+==== 응답 (Response)
+include::{snippets}/timeslot-get-list/http-response.adoc[]
+include::{snippets}/timeslot-get-list/response-fields.adoc[]
+
+---
+
+[[timeslot-create-bulk]]
+=== 2. 타임슬롯 일괄 생성 (관리자 전용)
+특정 식당의 타임슬롯을 지정된 기간과 간격에 맞춰 일괄 생성합니다.
+
+==== 요청 (Request)
+include::{snippets}/timeslot-create-bulk/http-request.adoc[]
+include::{snippets}/timeslot-create-bulk/request-headers.adoc[]
+include::{snippets}/timeslot-create-bulk/path-parameters.adoc[]
+include::{snippets}/timeslot-create-bulk/request-fields.adoc[]
+
+==== 응답 (Response)
+include::{snippets}/timeslot-create-bulk/http-response.adoc[]
+include::{snippets}/timeslot-create-bulk/response-fields.adoc[]
+
+---
+
+[[timeslot-get-calendar]]
+=== 3. 월간 달력 조회
+특정 식당의 특정 월에 대한 예약 가능 여부(달력)를 조회합니다.
+
+==== 요청 (Request)
+include::{snippets}/timeslot-get-calendar/http-request.adoc[]
+include::{snippets}/timeslot-get-calendar/path-parameters.adoc[]
+include::{snippets}/timeslot-get-calendar/query-parameters.adoc[]
+
+==== 응답 (Response)
+include::{snippets}/timeslot-get-calendar/http-response.adoc[]
+include::{snippets}/timeslot-get-calendar/response-fields.adoc[]

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
@@ -24,6 +25,19 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedRequestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -31,24 +45,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-/**
- * [External API Test]
- * 클라이언트 통신을 담당하는 TimeSlotExternalController의 동작을 검증합니다.
- */
 @WebMvcTest(
     controllers = TimeSlotExternalController.class,
     includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = GlobalExceptionHandler.class),
     excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)
 )
 @AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs 
 class TimeSlotExternalControllerTest {
 
     @Autowired
@@ -61,7 +69,7 @@ class TimeSlotExternalControllerTest {
     private TimeSlotService timeSlotService;
 
     @MockitoBean
-    private UserContextInterceptor userContextInterceptor; 
+    private UserContextInterceptor userContextInterceptor;
 
     @BeforeEach
     void setUp() {
@@ -74,72 +82,103 @@ class TimeSlotExternalControllerTest {
         UserContextHolder.clear();
     }
 
-
-    /**
-     * [GET] 특정 날짜의 타임슬롯 목록을 조회하면 DTO 리스트로 반환한다.
-     * @throws Exception
-     */
     @Test
-    @DisplayName("[GET] 특정 날짜의 타임슬롯 목록을 조회하면 DTO 리스트로 반환한다.")
-    void getTimeSlots_Success() throws Exception {
+    @DisplayName("[GET] 특정 날짜의 타임슬롯 목록 조회 문서화")
+    void getTimeSlots_Docs() throws Exception {
         UUID restaurantId = UUID.randomUUID();
-        LocalDate date = LocalDate.of(2036, 5, 5);
+        LocalDate date = LocalDate.of(2026, 5, 5);
         TimeSlot mockSlot = TimeSlotTestBuilder.aTimeSlot().targetDate(date).build();
 
-        given(timeSlotService.getTimeSlotsByDate(restaurantId, date))
-                .willReturn(List.of(mockSlot));
+        given(timeSlotService.getTimeSlotsByDate(restaurantId, date)).willReturn(List.of(mockSlot));
 
         mockMvc.perform(get("/api/v1/restaurants/{restaurantId}/time-slots", restaurantId)
                         .param("targetDate", date.toString())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].timeSlotId").value(mockSlot.getId().toString()));
+                .andDo(document("timeslot-get-list", 
+                        pathParameters(
+                                parameterWithName("restaurantId").description("식당 고유 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("targetDate").description("조회 대상 날짜 (YYYY-MM-DD)")
+                        ),
+                        relaxedResponseFields(
+                                fieldWithPath("success").description("요청 성공 여부"),
+                                fieldWithPath("data[].timeSlotId").description("타임슬롯 ID"),
+                                fieldWithPath("data[].startTime").description("시작 시간"),
+                                fieldWithPath("data[].endTime").description("종료 시간"),
+                                fieldWithPath("data[].capacity").description("최대 수용 인원"),
+                                fieldWithPath("data[].remainingCapacity").description("잔여 수용 인원"),
+                                fieldWithPath("data[].status").description("상태 (OPENED, CLOSED)")
+                        )
+                ));
     }
 
-    /**
-     * [POST] 일괄 생성 요청 시 DTO의 값을 낱개로 분해하여 서비스에 전달한다.
-     * @throws Exception
-     */
     @Test
-    @DisplayName("[POST] 일괄 생성 요청 시 DTO의 값을 낱개로 분해하여 서비스에 전달한다.")
-    void createTimeSlotsBulk_Success() throws Exception {
+    @DisplayName("[POST] 타임슬롯 일괄 생성 문서화")
+    void createTimeSlotsBulk_Docs() throws Exception {
         UUID restaurantId = UUID.randomUUID();
         TimeSlotBulkCreateRequest request = new TimeSlotBulkCreateRequest(
-                LocalDate.of(2036, 5, 10), LocalDate.of(2036, 5, 15),
+                LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 15),
                 LocalTime.of(9, 0), LocalTime.of(21, 0), 30, 4
         );
 
         mockMvc.perform(post("/api/v1/restaurants/{restaurantId}/time-slots/bulk", restaurantId)
+                        .header("X-User-Id", "550e8400-e29b-41d4-a716-446655440000")
+                        .header("X-User-Role", "OWNER")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-
-        verify(timeSlotService).createTimeSlotsBulk(
-                eq(restaurantId), eq(request.startDate()), eq(request.endDate()),
-                eq(request.openTime()), eq(request.closeTime()), 
-                eq(request.intervalMinutes()), eq(request.capacity())
-        );
+                .andExpect(status().isOk())
+                .andDo(document("timeslot-create-bulk",
+                        pathParameters(
+                                parameterWithName("restaurantId").description("식당 고유 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName("X-User-Id").description("사용자 고유 ID (인증)"),
+                                headerWithName("X-User-Role").description("사용자 권한 (OWNER 필수)")
+                        ),
+                        relaxedRequestFields(
+                                fieldWithPath("startDate").description("생성 시작 일자"),
+                                fieldWithPath("endDate").description("생성 종료 일자"),
+                                fieldWithPath("openTime").description("영업 시작 시간"),
+                                fieldWithPath("closeTime").description("영업 종료 시간"),
+                                fieldWithPath("intervalMinutes").description("타임슬롯 단위(분)"),
+                                fieldWithPath("capacity").description("타임슬롯 당 수용 인원")
+                        ),
+                        relaxedResponseFields(
+                                fieldWithPath("success").description("요청 성공 여부"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("응답 데이터 (없음)").optional()
+                        )
+                ));
     }
 
-    /**
-     * [GET] 월간 달력 조회 시 서비스가 반환한 Map을 DTO 규격에 맞춰 응답한다.
-     * @throws Exception
-     */
     @Test
-    @DisplayName("[GET] 월간 달력 조회 시 서비스가 반환한 Map을 DTO 규격에 맞춰 응답한다.")
-    void getCalendarByMonth_Success() throws Exception {
+    @DisplayName("[GET] 월간 달력 조회 문서화")
+    void getCalendarByMonth_Docs() throws Exception {
         UUID restaurantId = UUID.randomUUID();
-        LocalDate date = LocalDate.of(2036, 5, 1);
+        LocalDate date = LocalDate.of(2026, 5, 1);
         
-        given(timeSlotService.getCalendarByMonth(any(), eq(2036), eq(5)))
+        given(timeSlotService.getCalendarByMonth(any(), eq(2026), eq(5)))
                 .willReturn(Map.of(date, TimeSlotStatus.OPENED));
 
         mockMvc.perform(get("/api/v1/restaurants/{restaurantId}/time-slots/calendar", restaurantId)
-                        .param("year", "2036")
+                        .param("year", "2026")
                         .param("month", "5")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data[0].date").value("2036-05-01"))
-                .andExpect(jsonPath("$.data[0].status").value("OPENED"));
+                .andDo(document("timeslot-get-calendar",
+                        pathParameters(
+                                parameterWithName("restaurantId").description("식당 고유 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("year").description("조회 연도 (예: 2026)"),
+                                parameterWithName("month").description("조회 월 (1~12)")
+                        ),
+                        relaxedResponseFields(
+                                fieldWithPath("success").description("요청 성공 여부"),
+                                fieldWithPath("data[].date").description("날짜 (YYYY-MM-DD)"),
+                                fieldWithPath("data[].status").description("해당 일자 예약 가능 여부 (true: 가능, false: 마감)")
+                        )
+                ));
     }
 }

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotExternalControllerTest.java
@@ -86,7 +86,7 @@ class TimeSlotExternalControllerTest {
     @DisplayName("[GET] 특정 날짜의 타임슬롯 목록 조회 문서화")
     void getTimeSlots_Docs() throws Exception {
         UUID restaurantId = UUID.randomUUID();
-        LocalDate date = LocalDate.of(2026, 5, 5);
+        LocalDate date = LocalDate.of(2036, 5, 5);
         TimeSlot mockSlot = TimeSlotTestBuilder.aTimeSlot().targetDate(date).build();
 
         given(timeSlotService.getTimeSlotsByDate(restaurantId, date)).willReturn(List.of(mockSlot));
@@ -119,7 +119,7 @@ class TimeSlotExternalControllerTest {
     void createTimeSlotsBulk_Docs() throws Exception {
         UUID restaurantId = UUID.randomUUID();
         TimeSlotBulkCreateRequest request = new TimeSlotBulkCreateRequest(
-                LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 15),
+                LocalDate.of(2036, 5, 10), LocalDate.of(2036, 5, 15),
                 LocalTime.of(9, 0), LocalTime.of(21, 0), 30, 4
         );
 
@@ -156,13 +156,13 @@ class TimeSlotExternalControllerTest {
     @DisplayName("[GET] 월간 달력 조회 문서화")
     void getCalendarByMonth_Docs() throws Exception {
         UUID restaurantId = UUID.randomUUID();
-        LocalDate date = LocalDate.of(2026, 5, 1);
+        LocalDate date = LocalDate.of(2036, 5, 1);
         
-        given(timeSlotService.getCalendarByMonth(any(), eq(2026), eq(5)))
+        given(timeSlotService.getCalendarByMonth(any(), eq(2036), eq(5)))
                 .willReturn(Map.of(date, TimeSlotStatus.OPENED));
 
         mockMvc.perform(get("/api/v1/restaurants/{restaurantId}/time-slots/calendar", restaurantId)
-                        .param("year", "2026")
+                        .param("year", "2036")
                         .param("month", "5")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -171,13 +171,13 @@ class TimeSlotExternalControllerTest {
                                 parameterWithName("restaurantId").description("식당 고유 ID")
                         ),
                         queryParameters(
-                                parameterWithName("year").description("조회 연도 (예: 2026)"),
+                                parameterWithName("year").description("조회 연도 (예: 2036)"),
                                 parameterWithName("month").description("조회 월 (1~12)")
                         ),
                         relaxedResponseFields(
                                 fieldWithPath("success").description("요청 성공 여부"),
                                 fieldWithPath("data[].date").description("날짜 (YYYY-MM-DD)"),
-                                fieldWithPath("data[].status").description("해당 일자 예약 가능 여부 (true: 가능, false: 마감)")
+                                fieldWithPath("data[].status").description("해당 일자 예약 가능 여부 (true: OPENED, false: CLOSED)")
                         )
                 ));
     }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 빠른 로컬 테스트를 위한 .http 스크립트를 구성 및 RestDocs 작성으로 인한 API 명세화

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #30   \

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1108" height="322" alt="image" src="https://github.com/user-attachments/assets/7997502c-6a29-4fca-8f4f-1cc83d45cd43" />
<br><br>
<img width="1473" height="939" alt="image" src="https://github.com/user-attachments/assets/d356ddc7-b5ef-43bb-9f9b-c83985a136d7" />


---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * TimeSlot API에 대한 완전한 AsciiDoc 기반 API 문서가 추가되었습니다.
  * 시간대 조회, 일괄 생성, 월간 캘린더 조회 등 엔드포인트 설명과 요청/응답 예시가 포함됩니다.
* **도구/배포**
  * 빌드 산출물에 생성된 API 문서가 포함되어 애플리케이션의 정적 문서로 제공됩니다.
* **테스트**
  * API 문서 생성을 위한 테스트 문서화가 추가되어 문서 예시가 자동 생성됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->