### PR TITLE
[CHORE] API 게이트웨이 라우팅 및 유레카 연동 설정

### DIFF
--- a/http/timeslot-api.http
+++ b/http/timeslot-api.http
@@ -4,6 +4,7 @@
 @restaurantId = d4246628-b7da-47ab-95bb-a126395f0628
 @timeSlotId = b184211a-bd71-478e-8f14-ce889ba9db1d
 @ownerToken = {{ownerToken}}
+@userToken = {{userToken}}
 @X-User-Id = 550e8400-e29b-41d4-a716-446655440000
 @X-User-Role = OWNER
 @X-Internal-Token = {{X-Internal-Token}}
@@ -12,7 +13,7 @@
 ### 1. [외부 API] 특정 날짜의 타임슬롯 목록 조회
 GET {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/time-slots?targetDate=2026-05-31
 Accept: application/json
-Authorization: Bearer {{ownerToken}}
+Authorization: Bearer {{userToken}}
 
 ### 2. [외부 API] 타임슬롯 일괄 생성 (관리자 전용)
 POST {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/time-slots/bulk
@@ -31,7 +32,7 @@ Authorization: Bearer {{ownerToken}}
 
 ### 3. [외부 API] 월간 달력(예약 가능 여부) 조회
 GET {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/time-slots/calendar?year=2026&month=5
-Authorization: Bearer {{ownerToken}}
+Authorization: Bearer {{userToken}}
 Accept: application/json
 
 

--- a/http/timeslot-api.http
+++ b/http/timeslot-api.http
@@ -1,6 +1,6 @@
 ### 환경 변수 설정
 @gatewayUrl = http://localhost:19000
-@timeslotServiceUrl = http://localhost:19400
+@timeSlotServiceUrl = http://localhost:19400
 @restaurantId = d4246628-b7da-47ab-95bb-a126395f0628
 @timeSlotId = b184211a-bd71-478e-8f14-ce889ba9db1d
 @ownerToken = {{ownerToken}}

--- a/http/timeslot-api.http
+++ b/http/timeslot-api.http
@@ -36,7 +36,7 @@ Accept: application/json
 
 
 ### 4. [내부 API] deductTimeSlotCapacity - 예약 시 타임슬롯의 남은 좌석 수 감소
-POST {{timeslotServiceUrl}}/internal/v1/timeslots/{{timeSlotId}}/deduct
+POST {{timeSlotServiceUrl}}/internal/v1/timeslots/{{timeSlotId}}/deduct
 Content-Type: application/json
 X-User-Id: {{X-User-Id}}
 X-User-Role: {{X-User-Role}}

--- a/http/timeslot-api.http
+++ b/http/timeslot-api.http
@@ -1,18 +1,23 @@
 ### 환경 변수 설정
-@host = http://localhost:19400
+@gatewayUrl = http://localhost:19000
+@timeslotServiceUrl = http://localhost:19400
 @restaurantId = d4246628-b7da-47ab-95bb-a126395f0628
+@timeSlotId = b184211a-bd71-478e-8f14-ce889ba9db1d
+@ownerToken = {{ownerToken}}
 @X-User-Id = 550e8400-e29b-41d4-a716-446655440000
 @X-User-Role = OWNER
+@X-Internal-Token = {{X-Internal-Token}}
+
+
 ### 1. [외부 API] 특정 날짜의 타임슬롯 목록 조회
-GET {{host}}/api/v1/restaurants/{{restaurantId}}/time-slots?targetDate=2026-05-31
+GET {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/time-slots?targetDate=2026-05-31
 Accept: application/json
+Authorization: Bearer {{ownerToken}}
 
 ### 2. [외부 API] 타임슬롯 일괄 생성 (관리자 전용)
-POST {{host}}/api/v1/restaurants/{{restaurantId}}/time-slots/bulk
+POST {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/time-slots/bulk
 Content-Type: application/json
-X-User-Id: {{X-User-Id}}
-X-User-Role: {{X-User-Role}}
-
+Authorization: Bearer {{ownerToken}}
 
 {
   "startDate": "2026-05-05",
@@ -23,6 +28,20 @@ X-User-Role: {{X-User-Role}}
   "capacity": 4
 }
 
+
 ### 3. [외부 API] 월간 달력(예약 가능 여부) 조회
-GET {{host}}/api/v1/restaurants/{{restaurantId}}/time-slots/calendar?year=2026&month=5
+GET {{gatewayUrl}}/api/v1/restaurants/{{restaurantId}}/time-slots/calendar?year=2026&month=5
+Authorization: Bearer {{ownerToken}}
 Accept: application/json
+
+
+### 4. [내부 API] deductTimeSlotCapacity - 예약 시 타임슬롯의 남은 좌석 수 감소
+POST {{timeslotServiceUrl}}/internal/v1/timeslots/{{timeSlotId}}/deduct
+Content-Type: application/json
+X-User-Id: {{X-User-Id}}
+X-User-Role: {{X-User-Role}}
+X-Internal-Token: {{X-Internal-Token}}
+
+{
+  "requiredCapacity": 1
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: timeslot-service
 
   datasource:
-    url: jdbc:postgresql://${DB_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:michelet_db}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:michelet_db}?currentSchema=timeslot_service
     username: ${POSTGRES_USER:admin}
     password: ${POSTGRES_PASSWORD:admin}
     driver-class-name: org.postgresql.Driver
@@ -17,6 +17,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
+        default_schema: timeslot_service
         format_sql: true
         highlight_sql: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,25 +6,28 @@ spring:
     name: timeslot-service
 
   datasource:
-    url: jdbc:postgresql://localhost:19410/timeslot_db
-    username: admin
-    password: admin
+    url: jdbc:postgresql://${DB_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:michelet_db}
+    username: ${POSTGRES_USER:admin}
+    password: ${POSTGRES_PASSWORD:admin}
     driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
     show-sql: true
     properties:
       hibernate:
         format_sql: true
         highlight_sql: true
 
+
 internal:
   auth:
-    secret: ${SPRING_INTERNAL_AUTH_SECRET}
+    secret: ${SPRING_INTERNAL_AUTH_SECRET:michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc}
 
 eureka:
   client:
-    register-with-eureka: false
-    fetch-registry: false
+    register-with-eureka: true 
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,4 +30,4 @@ eureka:
     register-with-eureka: true 
     fetch-registry: true
     service-url:
-      defaultZone: http://localhost:8761/eureka/
+      defaultZone: ${EUREKA_DEFAULT_ZONE:http://localhost:8761/eureka/}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- API 게이트웨이의 라우팅 설정을 업데이트하고 유레카 서버(Service Discovery)와 통합, .http 수정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #32   \

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1117" height="312" alt="image" src="https://github.com/user-attachments/assets/673dd993-7a80-48f1-8126-1b8f998eebcd" />
<br><br>
<img width="1572" height="682" alt="image" src="https://github.com/user-attachments/assets/db42b649-e1d2-45da-a482-1ae1ba8837a4" />

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **설정 개선**
  * 데이터베이스 접속 정보(주소/사용자/비밀번호)를 환경 변수로 구성, JPA 동작을 환경 변수 기반으로 제어 가능하게 변경
  * 내부 인증 시크릿에 기본값 및 환경 변수 지원 추가

* **인프라 변경**
  * 서비스 디스커버리(Eureka) 등록 및 레지스트리 조회 활성화, 기본 서비스 URL을 환경 변수로 구성 가능

* **새로운 기능**
  * 예약 시간대의 가용 용량을 차감하는 내부 API 추가 및 외부 시간대 호출의 인증·대상 분리 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->