### PR TITLE
[FEAT] 타임슬롯 복구(Restore) 내부 API 구현 

### DIFF
--- a/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
+++ b/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
@@ -125,4 +125,22 @@ public class TimeSlotService {
             }
         }
     }
+
+    /**
+     * 결제 실패 혹은 오류시 타임슬롯 인원을 복원합니다.
+     * @param timeSlotId
+     * @param recoverCapacity
+     */
+
+    @Transactional
+    public void restoreTimeSlot(UUID timeSlotId, int recoverCapacity) {
+        TimeSlot timeSlot = timeSlotRepository.findById(timeSlotId)
+                .orElseThrow(() -> new BusinessException(TimeSlotErrorCode.TIME_SLOT_NOT_FOUND));
+
+        timeSlot.restore(recoverCapacity);
+
+        timeSlotRepository.save(timeSlot);
+
+    }
+
 }

--- a/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
+++ b/src/main/java/com/michelet/timeslotservice/application/service/TimeSlotService.java
@@ -133,7 +133,7 @@ public class TimeSlotService {
      */
 
     @Transactional
-    public void restoreTimeSlot(UUID timeSlotId, int recoverCapacity) {
+    public void restoreCapacity(UUID timeSlotId, int recoverCapacity) {
         TimeSlot timeSlot = timeSlotRepository.findById(timeSlotId)
                 .orElseThrow(() -> new BusinessException(TimeSlotErrorCode.TIME_SLOT_NOT_FOUND));
 

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -123,7 +123,7 @@ public class TimeSlot {
         
         this.remainingCapacity += restoreCapacity;
 
-        if (this.remainingCapacity >= 0) {
+        if (this.remainingCapacity > 0) {
             this.status = TimeSlotStatus.OPENED;
         }
     }

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -109,4 +109,23 @@ public class TimeSlot {
         }
     }
 
+    /**
+     * 타임슬롯 인원 복구 (보상 트랜잭션)
+     */
+    public void restore(int restoreCapacity) {
+        if (restoreCapacity <= 0) {
+            throw new BusinessException(TimeSlotErrorCode.INVALID_RESTORE_REQUEST);
+        }
+        
+        if (this.remainingCapacity + restoreCapacity > this.capacity) {
+            throw new BusinessException(TimeSlotErrorCode.INVALID_EXCEED_RESTORE_REQUEST);
+        }
+        
+        this.remainingCapacity += restoreCapacity;
+
+        if (this.remainingCapacity >= 0) {
+            this.status = TimeSlotStatus.OPENED;
+        }
+    }
+
 }

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -117,7 +117,7 @@ public class TimeSlot {
             throw new BusinessException(TimeSlotErrorCode.INVALID_RESTORE_REQUEST);
         }
         
-        if (this.remainingCapacity + restoreCapacity > this.capacity) {
+        if (restoreCapacity > this.capacity - this.remainingCapacity) {
             throw new BusinessException(TimeSlotErrorCode.INVALID_EXCEED_RESTORE_REQUEST);
         }
         

--- a/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/TimeSlot.java
@@ -123,7 +123,7 @@ public class TimeSlot {
         
         this.remainingCapacity += restoreCapacity;
 
-        if (this.remainingCapacity > 0) {
+        if (this.remainingCapacity > 0 && this.status == TimeSlotStatus.CLOSED) {
             this.status = TimeSlotStatus.OPENED;
         }
     }

--- a/src/main/java/com/michelet/timeslotservice/domain/exception/TimeSlotErrorCode.java
+++ b/src/main/java/com/michelet/timeslotservice/domain/exception/TimeSlotErrorCode.java
@@ -45,7 +45,13 @@ public enum TimeSlotErrorCode implements ErrorCode {
     FORBIDDEN("TS_011", 403, "권한이 없습니다."),
     
     /** 유효하지 않은 간격 에러 */
-    INVALID_INTERVAL("TS_012", 400, "타임슬롯 생성 간격이 유효하지 않습니다. 양수여야 합니다.");
+    INVALID_INTERVAL("TS_012", 400, "타임슬롯 생성 간격이 유효하지 않습니다. 양수여야 합니다."),
+
+    /** 유효하지 않은 복원 인원 요청 */
+    INVALID_RESTORE_REQUEST("TS_013", 400, "유효하지 않은 복원 인원 요청입니다. 요청된 인원 수는 1 이상이어야 합니다."),
+
+    /** 타임슬롯 복원시 최대 수용인원 초과 */
+    INVALID_EXCEED_RESTORE_REQUEST("TS_014", 400, "타임슬롯 최대 수용인원을 초과합니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/michelet/timeslotservice/presentation/code/TimeSlotSuccessCode.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/code/TimeSlotSuccessCode.java
@@ -9,7 +9,8 @@ public enum TimeSlotSuccessCode implements SuccessCode {
     
     INQUIRY_SUCCESS("TS_OK_001", "타임슬롯 조회가 완료되었습니다."),
     DEDUCT_SUCCESS("TS_OK_002", "타임슬롯 예약 차감이 완료되었습니다."),
-    BULK_CREATE_SUCCESS("TS_OK_003", "타임슬롯 일괄 생성이 완료되었습니다.");
+    BULK_CREATE_SUCCESS("TS_OK_003", "타임슬롯 일괄 생성이 완료되었습니다."),
+    RESTORE_SUCCESS("TS_OK_004", "타임슬롯 인원 복원처리가 완료되었습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotInternalController.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotInternalController.java
@@ -12,7 +12,7 @@ import com.michelet.common.response.ApiResponse;
 import com.michelet.timeslotservice.application.service.TimeSlotService;
 import com.michelet.timeslotservice.presentation.code.TimeSlotSuccessCode;
 import com.michelet.timeslotservice.presentation.dto.request.TimeSlotDeductCapacityRequest;
-import com.michelet.timeslotservice.presentation.dto.request.TimeSlotRestoreRequest;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotRestoreCapacityRequest;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -49,11 +49,11 @@ public class TimeSlotInternalController {
      */
 
     @PatchMapping("/{timeSlotId}/restore")
-    public ApiResponse<Void> restoreTimeSlot(
+    public ApiResponse<Void> restoreCapacity(
             @PathVariable UUID timeSlotId,
-            @RequestBody @Valid TimeSlotRestoreRequest request) {
+            @RequestBody @Valid TimeSlotRestoreCapacityRequest request) {
         
-        timeSlotService.restoreTimeSlot(timeSlotId, request.restoreCapacity());
+        timeSlotService.restoreCapacity(timeSlotId, request.restoreCapacity());
         
         return ApiResponse.ok(TimeSlotSuccessCode.RESTORE_SUCCESS, null);
     }

--- a/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotInternalController.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/controller/TimeSlotInternalController.java
@@ -2,8 +2,8 @@ package com.michelet.timeslotservice.presentation.controller;
 
 import java.util.UUID;
 
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,12 +12,13 @@ import com.michelet.common.response.ApiResponse;
 import com.michelet.timeslotservice.application.service.TimeSlotService;
 import com.michelet.timeslotservice.presentation.code.TimeSlotSuccessCode;
 import com.michelet.timeslotservice.presentation.dto.request.TimeSlotDeductCapacityRequest;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotRestoreRequest;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/internal/v1/timeslots")
+@RequestMapping("/internal/v1/time-slots")
 @RequiredArgsConstructor
 public class TimeSlotInternalController {
 
@@ -30,7 +31,7 @@ public class TimeSlotInternalController {
      * @param request 차감 요청 정보 (인원 수)
      * @return 공통 응답 규격
      */    
-    @PostMapping("/{timeSlotId}/deduct")
+    @PatchMapping("/{timeSlotId}/deduct")
     public ApiResponse<Void> deductCapacity(
             @PathVariable UUID timeSlotId, 
             @Valid @RequestBody TimeSlotDeductCapacityRequest request) {
@@ -38,6 +39,23 @@ public class TimeSlotInternalController {
         timeSlotService.deductCapacity(timeSlotId, request.requiredCapacity());
         return ApiResponse.ok(TimeSlotSuccessCode.DEDUCT_SUCCESS, null);
         
+    }
+
+    /**
+     * 특정 타임슬롯의 예약 인원을 복원하는 내부 API 엔드포인트.
+     * @param timeSlotId
+     * @param request
+     * @return
+     */
+
+    @PatchMapping("/{timeSlotId}/restore")
+    public ApiResponse<Void> restoreTimeSlot(
+            @PathVariable UUID timeSlotId,
+            @RequestBody @Valid TimeSlotRestoreRequest request) {
+        
+        timeSlotService.restoreTimeSlot(timeSlotId, request.restoreCapacity());
+        
+        return ApiResponse.ok(TimeSlotSuccessCode.RESTORE_SUCCESS, null);
     }
 
 }

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotRestoreCapacityRequest.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotRestoreCapacityRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Min;
 /**
  * 타임슬롯 인원 복구 요청 DTO
  */
-public record TimeSlotRestoreRequest(
+public record TimeSlotRestoreCapacityRequest(
 
     @Min(value = 1, message = "복구 인원은 최소 1명 이상이어야 합니다.")
     int restoreCapacity

--- a/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotRestoreRequest.java
+++ b/src/main/java/com/michelet/timeslotservice/presentation/dto/request/TimeSlotRestoreRequest.java
@@ -1,0 +1,13 @@
+package com.michelet.timeslotservice.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+/**
+ * 타임슬롯 인원 복구 요청 DTO
+ */
+public record TimeSlotRestoreRequest(
+
+    @Min(value = 1, message = "복구 인원은 최소 1명 이상이어야 합니다.")
+    int restoreCapacity
+) {
+}

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotInternalControllerTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotInternalControllerTest.java
@@ -11,6 +11,7 @@ import com.michelet.timeslotservice.application.service.TimeSlotService;
 import com.michelet.timeslotservice.domain.exception.TimeSlotErrorCode;
 import com.michelet.timeslotservice.infrastructure.config.WebConfig;
 import com.michelet.timeslotservice.presentation.dto.request.TimeSlotDeductCapacityRequest;
+import com.michelet.timeslotservice.presentation.dto.request.TimeSlotRestoreCapacityRequest;
 import com.michelet.timeslotservice.support.builder.TimeSlotTestBuilder;
 
 import org.junit.jupiter.api.AfterEach;
@@ -30,7 +31,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -83,7 +84,7 @@ class TimeSlotInternalControllerTest {
         TimeSlotDeductCapacityRequest request = new TimeSlotDeductCapacityRequest(3);
 
         // when & then
-        mockMvc.perform(post("/internal/v1/timeslots/{timeSlotId}/deduct", TimeSlotTestBuilder.DEFAULT_ID)
+        mockMvc.perform(patch("/internal/v1/time-slots/{timeSlotId}/deduct", TimeSlotTestBuilder.DEFAULT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
@@ -102,7 +103,7 @@ class TimeSlotInternalControllerTest {
         TimeSlotDeductCapacityRequest invalidRequest = new TimeSlotDeductCapacityRequest(0);
 
         // when & then
-        mockMvc.perform(post("/internal/v1/timeslots/{timeSlotId}/deduct", TimeSlotTestBuilder.DEFAULT_ID)
+        mockMvc.perform(patch("/internal/v1/time-slots/{timeSlotId}/deduct", TimeSlotTestBuilder.DEFAULT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidRequest)))
                 .andExpect(status().isBadRequest());
@@ -123,7 +124,7 @@ class TimeSlotInternalControllerTest {
                 .given(timeSlotService).deductCapacity(eq(TimeSlotTestBuilder.DEFAULT_ID), eq(100));
 
         // when & then
-        mockMvc.perform(post("/internal/v1/timeslots/{timeSlotId}/deduct", TimeSlotTestBuilder.DEFAULT_ID)
+        mockMvc.perform(patch("/internal/v1/time-slots/{timeSlotId}/deduct", TimeSlotTestBuilder.DEFAULT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -144,10 +145,51 @@ class TimeSlotInternalControllerTest {
                 .given(timeSlotService).deductCapacity(eq(fakeId), eq(2));
 
         // when & then
-        mockMvc.perform(post("/internal/v1/timeslots/{timeSlotId}/deduct", fakeId)
+        mockMvc.perform(patch("/internal/v1/time-slots/{timeSlotId}/deduct", fakeId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(TimeSlotErrorCode.TIME_SLOT_NOT_FOUND.getCode()));
+    }
+
+
+    /**
+     * 성공 케이스: 타임슬롯 정원 복원 요청이 정상적으로 처리되고, 서비스의 restoreCapacity 메서드가 올바른 인자로 호출되는지 검증합니다.
+     * @throws Exception
+     */
+    @Test
+    @DisplayName("[Internal] 타임슬롯 인원 복원 요청이 성공적으로 처리된다.")
+    void restoreCapacity_Success() throws Exception {
+        // given
+        TimeSlotRestoreCapacityRequest request = new TimeSlotRestoreCapacityRequest(3);
+
+        // when & then
+        mockMvc.perform(patch("/internal/v1/time-slots/{timeSlotId}/restore", TimeSlotTestBuilder.DEFAULT_ID)
+                        .param("remainingCapacity", "0")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+                
+        then(timeSlotService).should().restoreCapacity(eq(TimeSlotTestBuilder.DEFAULT_ID), eq(3));
+    }
+
+    /**
+     * 비즈니스 로직 예외 1 (남은 정원 초과)
+     */
+    @Test
+    @DisplayName("[Internal] 복원을 요청시 남은 정원을 초과하면 INVALID_EXCEED_RESTORE_REQUEST 예외 응답을 반환한다.")
+    void restoreCapacity_Fail_ExceedCapacity() throws Exception {
+        // given
+        TimeSlotRestoreCapacityRequest request = new TimeSlotRestoreCapacityRequest(100);
+        
+        willThrow(new BusinessException(TimeSlotErrorCode.INVALID_EXCEED_RESTORE_REQUEST))
+                .given(timeSlotService).restoreCapacity(eq(TimeSlotTestBuilder.DEFAULT_ID), eq(100));
+
+        // when & then
+        mockMvc.perform(patch("/internal/v1/time-slots/{timeSlotId}/restore", TimeSlotTestBuilder.DEFAULT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(TimeSlotErrorCode.INVALID_EXCEED_RESTORE_REQUEST.getCode()));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 결제 실패, 사용자 예약 취소, 선점 타임아웃 발생 시 차감되었던 타임슬롯의 수용 인원을 원상 복구하는 보상 트랜잭션 기능 구현.

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #42   \

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1539" height="509" alt="image" src="https://github.com/user-attachments/assets/4a805b0e-6499-4f01-bc03-70874476cb8b" />
<br><br>
<img width="516" height="532" alt="image" src="https://github.com/user-attachments/assets/94f0abd9-ad06-401d-b9b8-a2a41e80d1df" />
<br><br>
<img width="682" height="587" alt="image" src="https://github.com/user-attachments/assets/e0deedc9-e1f7-4f47-ad26-97badc169199" />


<br><br><br>

---
내부 API URL 에서 timeslots 를 time-slots 로 변경하였습니다
또한 deduct request method 를 POST 에서 PATCH 로 수정하였습니다

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 타임슬롯의 예약 인원을 복원하는 API 기능이 추가되었습니다.

* **Changes**
  * 내부 API의 기본 경로가 `/internal/v1/timeslots`에서 `/internal/v1/time-slots`로 변경되었습니다.
  * 용량 차감 엔드포인트의 HTTP 메서드가 POST에서 PATCH로 변경되었습니다.
  * 인원 복원 처리를 위한 새로운 PATCH 엔드포인트가 추가되었습니다.
  * 복원 인원에 대한 유효성 검사가 강화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/timeslot-service/pull/43)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->