### PR TITLE
[CHORE] Testcontainers 기반 PostgreSQL 통합 테스트 환경 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,9 @@ jobs:
 # 빌드 부분은 나중에 gradlew 경로 잡고 다시 살릴 예정
     # - name: Build with Gradle
     #   run: ./gradlew build # 빌드 및 테스트 코드를 실행함
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew clean build --no-daemon

--- a/build.gradle
+++ b/build.gradle
@@ -53,14 +53,13 @@ dependencies {
 
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-	
+
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
 
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testRuntimeOnly 'com.h2database:h2'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:postgresql'
 
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,11 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        hbm2ddl:
+          create_namespaces: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,13 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: ERROR 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
   application:
     name: timeslot-service
 
+  profiles:
+    active: local
+
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:michelet_db}?currentSchema=timeslot_service
     username: ${POSTGRES_USER:admin}
@@ -13,13 +16,10 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    show-sql: true
+      ddl-auto: validate
     properties:
       hibernate:
         default_schema: timeslot_service
-        format_sql: true
-        highlight_sql: true
 
 internal:
   auth:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: timeslot-service
 
   profiles:
-    active: local
+    default: local
 
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:michelet_db}?currentSchema=timeslot_service

--- a/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceIntegrationTest.java
+++ b/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceIntegrationTest.java
@@ -3,12 +3,12 @@ package com.michelet.timeslotservice.application.service;
 import com.michelet.common.exception.BusinessException;
 import com.michelet.timeslotservice.domain.TimeSlot;
 import com.michelet.timeslotservice.domain.repository.TimeSlotRepository;
+import com.michelet.timeslotservice.support.IntegrationTestSupport;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -27,8 +27,7 @@ import static com.michelet.timeslotservice.support.builder.TimeSlotTestBuilder.a
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-@SpringBootTest(properties = {"eureka.client.enabled=false"})
-class TimeSlotServiceIntegrationTest {
+class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private TimeSlotService timeSlotService;
@@ -116,4 +115,6 @@ class TimeSlotServiceIntegrationTest {
         List<TimeSlot> savedSlots = timeSlotRepository.findByDateRange(restaurantId, startDate, endDate);
         assertThat(savedSlots).hasSize(4);
     }
+
+    
 }

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotApiEndToEndTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotApiEndToEndTest.java
@@ -8,6 +8,8 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.michelet.timeslotservice.support.IntegrationTestSupport;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
@@ -18,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * [E2E Test] 실제 톰캣 서버를 띄우고 클라이언트 관점에서 API 흐름을 검증합니다.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {"eureka.client.enabled=false"})
-class TimeSlotApiEndToEndTest {
+class TimeSlotApiEndToEndTest extends IntegrationTestSupport {
 
     @Autowired
     private TestRestTemplate restTemplate;

--- a/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
+++ b/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
@@ -4,19 +4,17 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * 싱글톤 패턴을 이용한 PostgreSQL Testcontainer 사용
  */
 @ActiveProfiles("local")
 @SpringBootTest("eureka.client.enabled=false")
-@Testcontainers
 public abstract class IntegrationTestSupport {
 
     @SuppressWarnings("resource")
     @ServiceConnection
-    static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:latest")
+    static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:18")
             .withDatabaseName("timeslot_test")
             .withUsername("test")
             .withPassword("test");

--- a/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
+++ b/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
@@ -10,7 +10,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * 싱글톤 패턴을 이용한 PostgreSQL Testcontainer 사용
  */
 @ActiveProfiles("local")
-@SpringBootTest()
+@SpringBootTest("eureka.client.enabled=false")
 @Testcontainers
 public abstract class IntegrationTestSupport {
 

--- a/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
+++ b/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
@@ -1,0 +1,27 @@
+package com.michelet.timeslotservice.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * 싱글톤 패턴을 이용한 PostgreSQL Testcontainer 사용
+ */
+@ActiveProfiles("local")
+@SpringBootTest()
+@Testcontainers
+public abstract class IntegrationTestSupport {
+
+    @SuppressWarnings("resource")
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:latest")
+            .withDatabaseName("timeslot_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    static {
+        postgresContainer.start();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- H2 인메모리 DB를 대체하여, 운영 환경(AWS RDS PostgreSQL)과 100% 동일한 격리된 통합 테스트 환경 구축

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #45   \

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1540" height="735" alt="image" src="https://github.com/user-attachments/assets/61763fb7-0305-4915-a3dc-af3c2ce0287f" />
<br><br>
<img width="1233" height="81" alt="image" src="https://github.com/user-attachments/assets/e02bd099-6652-466d-ba1d-4c4cf6cd1a7a" />


---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI 워크플로우를 업데이트하여 PR에서 Gradle 빌드를 재활성화했습니다.
  * Testcontainers 기반 테스트 의존성을 추가했습니다.

* **Tests**
  * 통합 테스트 인프라를 개선하기 위해 기본 테스트 지원 클래스를 도입했습니다.
  * 테스트 환경을 위한 로컬 및 프로덕션 설정 프로필을 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/timeslot-service/pull/46)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->