### PR TITLE
[TEST] 타임슬롯 인원 복원(Restore) 통합 및 동시성 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
 
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceIntegrationTest.java
+++ b/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceIntegrationTest.java
@@ -5,18 +5,14 @@ import com.michelet.timeslotservice.domain.TimeSlot;
 import com.michelet.timeslotservice.domain.repository.TimeSlotRepository;
 import com.michelet.timeslotservice.support.IntegrationTestSupport;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.AuditorAware;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -24,8 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.michelet.timeslotservice.support.builder.TimeSlotTestBuilder.aTimeSlot;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.*;
 
 class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
 
@@ -34,14 +29,6 @@ class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private TimeSlotRepository timeSlotRepository;
-
-    @MockitoBean
-    private AuditorAware<UUID> auditorAware;
-
-    @BeforeEach
-    void setUp() {
-        given(auditorAware.getCurrentAuditor()).willReturn(Optional.of(UUID.randomUUID()));
-    }
 
     /**
      * [통합] 1자리 남은 타임슬롯에 100명이 동시에 예약을 요청하면 1명만 성공하고 99명은 실패해야 한다.
@@ -114,6 +101,96 @@ class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
         // then
         List<TimeSlot> savedSlots = timeSlotRepository.findByDateRange(restaurantId, startDate, endDate);
         assertThat(savedSlots).hasSize(4);
+    }
+
+
+    /**
+     * [통합] 1. 정상 흐름: 예약 취소 시 타임슬롯의 남은 자리가 정확히 복구된다.
+     */
+    @Test
+    @DisplayName("[통합] 예약 취소 시 타임슬롯의 남은 자리가 요청한 만큼(1) 정상 복구된다.")
+    void restoreCapacity_Success() {
+        // given
+        TimeSlot slot = aTimeSlot()
+            .id(null)
+            .restaurantId(UUID.randomUUID())
+            .capacity(4)
+            .remainingCapacity(2)
+            .build();
+        TimeSlot savedSlot = timeSlotRepository.save(slot);
+
+        // when
+        timeSlotService.restoreCapacity(savedSlot.getId(), 1);
+
+        // then
+        TimeSlot updatedSlot = timeSlotRepository.findById(savedSlot.getId()).orElseThrow();
+        assertThat(updatedSlot.getRemainingCapacity()).isEqualTo(3);
+    }
+
+    /**
+     * [통합] 2. 예외 흐름: 정원 초과 방어
+     */
+    @Test
+    @DisplayName("[통합] 최대 수용 인원을 초과하여 복구하려고 하면 BusinessException이 발생한다.")
+    void restoreCapacity_Fail_ExceedMaxCapacity() {
+        // given: 정원 4명, 남은 자리가 이미 4명(예약자 0명)인 타임슬롯
+        TimeSlot slot = aTimeSlot()
+            .id(null)
+            .restaurantId(UUID.randomUUID())
+            .capacity(4)
+            .remainingCapacity(4)
+            .build();
+        TimeSlot savedSlot = timeSlotRepository.save(slot);
+
+        // when & then: 1명을 추가로 복원하려 하면 예외가 발생해야 한다
+        assertThatThrownBy(() -> timeSlotService.restoreCapacity(savedSlot.getId(), 1))
+                .isInstanceOf(BusinessException.class); 
+                // 필요시 .hasMessageContaining() 등으로 구체적 검증 추가
+    }
+
+    /**
+     * [통합] 3. 동시성 제어: 다중 취소 요청 시 락(Lock) 검증
+     */
+    @Test
+    @DisplayName("[통합] 동일한 타임슬롯에 4건의 복구 요청이 동시 다발적으로 발생하면 락이 작동해야 한다.")
+    void restoreCapacity_ConcurrencyTest() throws InterruptedException {
+        // given
+        TimeSlot slot = aTimeSlot()
+            .id(null)
+            .restaurantId(UUID.randomUUID())
+            .capacity(4)
+            .remainingCapacity(0)
+            .build();
+        TimeSlot savedSlot = timeSlotRepository.save(slot);
+
+        int threadCount = 4;
+        ExecutorService executorService = Executors.newFixedThreadPool(4);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    timeSlotService.restoreCapacity(savedSlot.getId(), 1);
+                    successCount.incrementAndGet();
+                } catch (ObjectOptimisticLockingFailureException | BusinessException e) {
+                    failCount.incrementAndGet(); // 락 충돌로 인해 실패한 건수
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // then: 동시성 덮어쓰기(Lost Update)가 방지되어야 하므로 4건 모두 성공할 수는 없습니다.
+        TimeSlot updatedSlot = timeSlotRepository.findById(savedSlot.getId()).orElseThrow();
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(3);
+        assertThat(updatedSlot.getRemainingCapacity()).isEqualTo(1);
     }
 
     

--- a/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceIntegrationTest.java
+++ b/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceIntegrationTest.java
@@ -164,7 +164,9 @@ class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
 
         int threadCount = 4;
         ExecutorService executorService = Executors.newFixedThreadPool(4);
-        CountDownLatch latch = new CountDownLatch(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
 
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failCount = new AtomicInteger(0);
@@ -173,16 +175,23 @@ class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
+                    ready.countDown();
+                    start.await();
                     timeSlotService.restoreCapacity(savedSlot.getId(), 1);
                     successCount.incrementAndGet();
                 } catch (ObjectOptimisticLockingFailureException | BusinessException e) {
                     failCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Test interrupted", e);
                 } finally {
-                    latch.countDown();
+                    done.countDown();
                 }
             });
         }
-        latch.await();
+        ready.await();
+        start.countDown();
+        done.await();
         executorService.shutdown();
 
         // then

--- a/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceIntegrationTest.java
+++ b/src/test/java/com/michelet/timeslotservice/application/service/TimeSlotServiceIntegrationTest.java
@@ -133,7 +133,7 @@ class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
     @Test
     @DisplayName("[통합] 최대 수용 인원을 초과하여 복구하려고 하면 BusinessException이 발생한다.")
     void restoreCapacity_Fail_ExceedMaxCapacity() {
-        // given: 정원 4명, 남은 자리가 이미 4명(예약자 0명)인 타임슬롯
+        // given
         TimeSlot slot = aTimeSlot()
             .id(null)
             .restaurantId(UUID.randomUUID())
@@ -142,10 +142,9 @@ class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
             .build();
         TimeSlot savedSlot = timeSlotRepository.save(slot);
 
-        // when & then: 1명을 추가로 복원하려 하면 예외가 발생해야 한다
+        // when & then
         assertThatThrownBy(() -> timeSlotService.restoreCapacity(savedSlot.getId(), 1))
                 .isInstanceOf(BusinessException.class); 
-                // 필요시 .hasMessageContaining() 등으로 구체적 검증 추가
     }
 
     /**
@@ -177,7 +176,7 @@ class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
                     timeSlotService.restoreCapacity(savedSlot.getId(), 1);
                     successCount.incrementAndGet();
                 } catch (ObjectOptimisticLockingFailureException | BusinessException e) {
-                    failCount.incrementAndGet(); // 락 충돌로 인해 실패한 건수
+                    failCount.incrementAndGet();
                 } finally {
                     latch.countDown();
                 }
@@ -186,7 +185,7 @@ class TimeSlotServiceIntegrationTest extends IntegrationTestSupport {
         latch.await();
         executorService.shutdown();
 
-        // then: 동시성 덮어쓰기(Lost Update)가 방지되어야 하므로 4건 모두 성공할 수는 없습니다.
+        // then
         TimeSlot updatedSlot = timeSlotRepository.findById(savedSlot.getId()).orElseThrow();
         assertThat(successCount.get()).isEqualTo(1);
         assertThat(failCount.get()).isEqualTo(3);

--- a/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotApiEndToEndTest.java
+++ b/src/test/java/com/michelet/timeslotservice/presentation/controller/TimeSlotApiEndToEndTest.java
@@ -3,27 +3,33 @@ package com.michelet.timeslotservice.presentation.controller;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.michelet.timeslotservice.domain.TimeSlot;
+import com.michelet.timeslotservice.domain.repository.TimeSlotRepository;
 import com.michelet.timeslotservice.support.IntegrationTestSupport;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 
+import static com.michelet.timeslotservice.support.builder.TimeSlotTestBuilder.aTimeSlot;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * [E2E Test] 실제 톰캣 서버를 띄우고 클라이언트 관점에서 API 흐름을 검증합니다.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {"eureka.client.enabled=false"})
+
 class TimeSlotApiEndToEndTest extends IntegrationTestSupport {
 
     @Autowired
     private TestRestTemplate restTemplate;
+
+    @Autowired
+    private TimeSlotRepository timeSlotRepository;
 
     /**
      * [E2E] 잘못된 날짜로 달력 조회를 요청하면 HTTP 400 에러와 함께 공통 에러 포맷이 반환된다.
@@ -87,5 +93,47 @@ class TimeSlotApiEndToEndTest extends IntegrationTestSupport {
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).contains("\"code\":\"VALIDATION_001\""); 
+    }
+
+
+    /**
+     * [E2E] 내부 서비스(결제 등)에서 타임슬롯 인원 복원(PATCH)을 요청하면 정상 처리된다.
+     */
+    @Test
+    @DisplayName("[E2E] 타임슬롯 인원 복원 요청 시 HTTP 200 OK가 반환된다.")
+    void restoreCapacity_E2E_Success() {
+        // given
+        TimeSlot timeSlot = aTimeSlot()
+                .id(null)
+                .restaurantId(java.util.UUID.randomUUID())
+                .targetDate(java.time.LocalDate.of(2099, 5, 20))
+                .time(java.time.LocalTime.of(14, 0), java.time.LocalTime.of(15, 0))
+                .capacity(4)
+                .remainingCapacity(2)
+                .build();
+
+        TimeSlot savedSlot = timeSlotRepository.save(timeSlot);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        headers.set("X-Internal-Token", createTestInternalToken());
+        
+        String requestBody = "{\"restoreCapacity\": 1}";
+        HttpEntity<String> request = new HttpEntity<>(requestBody, headers);
+
+        String url = "/internal/v1/time-slots/" + savedSlot.getId() + "/restore";
+
+        // when
+        ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.PATCH,
+                request,
+                String.class
+        );
+        System.out.println("응답 상태 코드: " + response.getStatusCode());
+        System.out.println("응답 바디: " + response.getBody());
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 }

--- a/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
+++ b/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
@@ -1,16 +1,59 @@
 package com.michelet.timeslotservice.support;
 
+import static org.mockito.BDDMockito.given;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.PostgreSQLContainer;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 
 /**
  * 싱글톤 패턴을 이용한 PostgreSQL Testcontainer 사용
  */
 @ActiveProfiles("local")
-@SpringBootTest("eureka.client.enabled=false")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, 
+    properties = {"eureka.client.enabled=false"}
+)
 public abstract class IntegrationTestSupport {
+
+    @MockitoBean
+    protected AuditorAware<UUID> auditorAware; 
+
+    @BeforeEach
+    void setUpAuditor() {
+        given(auditorAware.getCurrentAuditor()).willReturn(Optional.of(UUID.randomUUID()));
+    }
+
+
+    @Value("${internal.auth.secret}")
+    private String secretKey;
+
+    protected String createTestInternalToken() {
+        SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+
+        return Jwts.builder()
+                .issuer("michelet-admin")
+                .audience().add("timeslot-service").and()
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 10))
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+    }
 
     @SuppressWarnings("resource")
     @ServiceConnection

--- a/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
+++ b/src/test/java/com/michelet/timeslotservice/support/IntegrationTestSupport.java
@@ -31,6 +31,11 @@ import io.jsonwebtoken.security.Keys;
 )
 public abstract class IntegrationTestSupport {
 
+
+
+    /**
+     * Auditor 설정을 담당
+     */
     @MockitoBean
     protected AuditorAware<UUID> auditorAware; 
 
@@ -40,6 +45,9 @@ public abstract class IntegrationTestSupport {
     }
 
 
+    /**
+     * internal.auth.secret 을 이용하여 X-Internal-Token 생성
+     */
     @Value("${internal.auth.secret}")
     private String secretKey;
 
@@ -55,9 +63,12 @@ public abstract class IntegrationTestSupport {
                 .compact();
     }
 
+    /**
+     * PostgreSQL 테스트 컨테이너 생성
+     */
     @SuppressWarnings("resource")
     @ServiceConnection
-    static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:18")
+    static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:18.3")
             .withDatabaseName("timeslot_test")
             .withUsername("test")
             .withPassword("test");


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 예약 취소/결제 실패 시 동작하는 restoreCapacity 로직의 데이터 정합성 검증

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #47   \

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1545" height="445" alt="image" src="https://github.com/user-attachments/assets/c7fa4d76-4c62-4547-8614-ed40de28aaac" />


---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 타임슬롯 용량 복원 기능 추가

* **테스트**
  * 용량 복원에 대한 통합 테스트 3개 추가(성공, 초과 실패, 동시성)
  * 용량 복원 내부 엔드투엔드(E2E) 테스트 추가
  * 테스트 지원에 랜덤 포트·테스트 컨테이너 환경 설정 업데이트

* **잡무(Chore)**
  * JWT 라이브러리 추가로 내부 토큰 생성/검증 지원 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/timeslot-service/pull/48)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->